### PR TITLE
Small change in the positioning of a global var

### DIFF
--- a/crypt4gh/__init__.py
+++ b/crypt4gh/__init__.py
@@ -8,3 +8,5 @@ __version__ = VERSION = 1
 __author__ = 'Frédéric Haziza <frederic.haziza@crg.eu>'
 __license__ = 'Apache License 2.0'
 __copyright__ = __title__ + ' @ CRG'
+
+PROG = 'crypt4gh'

--- a/crypt4gh/cli.py
+++ b/crypt4gh/cli.py
@@ -7,9 +7,8 @@ import logging.config
 
 from docopt import docopt
 
-from . import __title__, __version__
+from . import __title__, __version__, PROG
 
-PROG = 'crypt4gh'
 DEFAULT_LOG = os.getenv('C4GH_LOG', None)
 
 __doc__ = f'''

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
-from crypt4gh import __version__, __author__, __title__, __doc__ as lega_doc, __license__
-from crypt4gh.cli import PROG
+from crypt4gh import __version__, __author__, __title__, __doc__ as lega_doc, __license__, PROG
 
 setup(name='crypt4gh',
       version=__version__,
@@ -16,7 +15,7 @@ setup(name='crypt4gh',
       zip_safe=False,
       entry_points={
           'console_scripts': [
-              f'{PROG} = crypt4gh.__main__:main',
+              f'{PROG} = crypt4gh.__main__:main' ,
           ]
       },
       platforms = 'any',
@@ -27,4 +26,4 @@ setup(name='crypt4gh',
           'pynacl',
           'docopt',
       ],
-)          
+)


### PR DESCRIPTION
This would help to move things along with the review of https://github.com/EGA-archive/LocalEGA/pull/3

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Code cleanup

### Pull request long description:
Reason for this change is to get rid of error such as this when trying to automate with `tox`:
```
╰─$ tox -r                                              
GLOB sdist-make: /home/stenegru/csc/dev/LocalEGA/setup.py
unit_tests create: /home/stenegru/csc/dev/LocalEGA/.tox/unit_tests
unit_tests installdeps: -rrequirements.txt, -rtests/requirements.txt
ERROR: invocation failed (exit code 1), logfile: /home/stenegru/csc/dev/LocalEGA/.tox/unit_tests/log/unit_tests-1.log
ERROR: actionid: unit_tests
msg: getenv
cmdargs: '/home/stenegru/csc/dev/LocalEGA/.tox/unit_tests/bin/python -m pip install -rrequirements.txt -rtests/requirements.txt'

Collecting git+https://github.com/EGA-archive/crypt4gh.git (from -r requirements.txt (line 11))
  Cloning https://github.com/EGA-archive/crypt4gh.git to /tmp/pip-req-build-v9yhcbqw
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-v9yhcbqw/setup.py", line 3, in <module>
        from crypt4gh.cli import PROG
      File "/tmp/pip-req-build-v9yhcbqw/crypt4gh/cli.py", line 8, in <module>
        from docopt import docopt
    ModuleNotFoundError: No module named 'docopt'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-req-build-v9yhcbqw/

ERROR: could not install deps [-rrequirements.txt, -rtests/requirements.txt]; v = InvocationError('/home/stenegru/csc/dev/LocalEGA/.tox/unit_tests/bin/python -m pip install -rrequirements.txt -rtests/requirements.txt (see /home/stenegru/csc/dev/LocalEGA/.tox/unit_tests/log/unit_tests-1.log)', 1)
```
Also it make more sense to have that kind of variable imported from `__init__.py`

What i think it happens: is that `tox` tries to install dependencies reaches crypt4gh runs `setup.py` but before it has the chance to install `docopt` it goes to `crypt4gh.cli` that imports the module, but that module is not installed yet ... but then again i might be wrong.

### Changes made:
Moved `PROG` from `crypt4gh/cli.py` to ` crypt4gh/__init__.py` and imported it accordingly in `setup.py` and `crypt4gh/cli.py`