### PR TITLE
Require at least python version 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ according to the [Crypt4GH Encryption format](specs).
 
 ## Installation
 
+Python `3.6+` required to use the crypt4gh encryption utility.
+
 ```
 git clone https://github.com/EGA-archive/crypt4gh
 pip install -r crypt4gh/requirements.txt

--- a/crypt4gh/__main__.py
+++ b/crypt4gh/__main__.py
@@ -130,4 +130,5 @@ def main(args=sys.argv[1:]):
     #     sys.exit(1)
 
 if __name__ == '__main__':
+    assert sys.version_info >= (3, 6), "This tool requires python3.6"
     main()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 import os
+import sys
 from setuptools import setup
+
+assert sys.version_info >= (3, 6), "crypt4gh requires at least python3.6"
+
 from crypt4gh import __version__, __author__, __title__, __doc__ as lega_doc, __license__, PROG
 
 here = os.path.dirname(__file__)
@@ -20,9 +24,10 @@ setup(name='crypt4gh',
       zip_safe=False,
       entry_points={
           'console_scripts': [
-              f'{PROG} = crypt4gh.__main__:main' ,
+              '{crypt4gh}=crypt4gh.__main__:main'.format(crypt4gh=PROG),
           ]
       },
       platforms = 'any',
+      python_requires='>=3.6',
       install_requires=packages,
 )


### PR DESCRIPTION
Small requirement for the python version as crypt4gh uses f strings + letting people know to get with the time.