### PR TITLE
Improving performance

### DIFF
--- a/crypt4gh/exceptions.py
+++ b/crypt4gh/exceptions.py
@@ -8,8 +8,9 @@ import sys
 import logging
 import errno
 
-from nacl.exceptions import InvalidkeyError, BadSignatureError, CryptoError
-from cryptography.exceptions import InvalidTag
+from nacl.exceptions import (InvalidkeyError,
+                             BadSignatureError,
+                             CryptoError)
 
 LOG = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ def exit_on_invalid_passphrase(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (InvalidTag) as e:
+        except CryptoError as e:
             LOG.error('Exiting for %r', e)
             print('Invalid Key or Passphrase', file=sys.stderr)
             sys.exit(2)

--- a/crypt4gh/keys/ssh.py
+++ b/crypt4gh/keys/ssh.py
@@ -4,7 +4,7 @@ import io
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
-from cryptography.exceptions import InvalidTag
+from nacl.exceptions import CryptoError
 from nacl.bindings.crypto_sign import crypto_sign_ed25519_pk_to_curve25519, crypto_sign_ed25519_sk_to_curve25519
 
 from .kdf import derive_key
@@ -170,7 +170,7 @@ def parse_private_key(stream, callback):
 
     if private_data[:4] != private_data[4:8]: # check don't pass
         LOG.debug('Check: %s != %s', private_data[:4], private_data[4:8])
-        raise InvalidTag() 
+        raise CryptoError()
     private_data = io.BytesIO(private_data[8:])
     # Note: we ignore the comment and padding after the priv blob
     return _get_skpk_from_private_blob(private_data) # no need to unpad

--- a/tests/_common/edit_list_gen.py
+++ b/tests/_common/edit_list_gen.py
@@ -12,10 +12,8 @@ import io
 from functools import partial
 from getpass import getpass
 
-from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
-
 from crypt4gh.keys import get_private_key, get_public_key
-from crypt4gh import header,lib, SEGMENT_SIZE
+from crypt4gh import header, lib, SEGMENT_SIZE
 
 if __name__ == '__main__':
 
@@ -73,7 +71,6 @@ if __name__ == '__main__':
     #############################################################
     encryption_method = 0 # only choice for this version
     session_key = os.urandom(32) # we use one session key for all blocks
-    cipher = ChaCha20Poly1305(session_key) # create a new one in case an old one is not reset
 
     #############################################################
     # Output the header
@@ -99,10 +96,10 @@ if __name__ == '__main__':
 
         if segment_len < SEGMENT_SIZE: # not a full segment
             data = bytes(segment[:segment_len]) # to discard the bytes from the previous segments
-            lib._encrypt_segment(data, outfile.write, cipher)
+            lib._encrypt_segment(data, outfile.write, session_key)
             break
 
         data = bytes(segment) # this is a full segment
-        lib._encrypt_segment(data, outfile.write, cipher)
+        lib._encrypt_segment(data, outfile.write, session_key)
 
 


### PR DESCRIPTION
We replaced openssl chacha20 encryption/decryption with the ones from libsodium (via the pynacl bindings)

The test was:
Starting from a 1G file, named `testfile` with random data, we encrypt and decrypt `n` times, using intermediate staging files. We make sure that last file is the same as the original file (with `diff`).

The test script is:
```
#!/usr/bin/env bash
set -e

LIMIT=${1:-10}

unlink testfile.v1.1 &>/dev/null || true
ln -s testfile testfile.1

for (( i=1; i<=$LIMIT; i++ ))
do
    echo -n "o"
    crypt4gh encrypt --sk from.sec --recipient_pk to.pub < testfile.$i  > testfile.c4gh.$i
    echo -n "."
    crypt4gh decrypt --sk to.sec < testfile.c4gh.$i > testfile.$((i+1))
    unlink testfile.$i
    unlink testfile.c4gh.$i
done

echo "|"
diff testfile testfile.$i
unlink testfile.$i
```

and we time the execution, with 50 loops.

| time  |   with openssl |  with libsodium |
|---|---|---|
| real  | 5m57.990s | 4m24.042s |
| user | 3m53.821s | 2m39.777s |
| sys  |  1m42.902s | 1m35.706s |

So it seems to bring an improvement of roughly 35%. Not bad.

We keep the `cryptography` dependency, because we use it to parse the ssh keys.