### PR TITLE
Fix small typos

### DIFF
--- a/crypt4gh/__init__.py
+++ b/crypt4gh/__init__.py
@@ -28,7 +28,7 @@ cryptographic file format."""
 # Knowing that the range <start-end> is applied to the "decrypted file" (ie the original content, as if no encryption was applied),
 # we have the two following cases:
 # - there is no Edit List: we fast-forward to the relevant cipher block (as <start-end> states).
-# - there is an Edit List: we reject the file if a cipher block is entirely skipped (independantly of the <start-end> range).
+# - there is an Edit List: we reject the file if a cipher block is entirely skipped (independently of the <start-end> range).
 # (If edit list and range are both used: we decipher each block and then apply the range)
 #
 #

--- a/crypt4gh/keys/kdf.py
+++ b/crypt4gh/keys/kdf.py
@@ -29,7 +29,8 @@ def get_kdf(kdfname):
 def derive_key(alg, passphrase, salt, rounds, dklen=32):
     if alg == b'scrypt':
         if not scrypt_supported:
-            raise ValueError("scrypt is not supported on this plateform")
+            from ssl import OPENSSL_VERSION
+            raise ValueError("scrypt is not supported on this platform. OpenSSL 1.1.+ required. Current OpenSSL version is: %s", OPENSSL_VERSION)
         return scrypt(passphrase, salt=salt, n=1<<14, r=8, p=1, dklen=dklen)
     if alg == b'bcrypt':
         import bcrypt

--- a/docs/keys.rst
+++ b/docs/keys.rst
@@ -46,6 +46,6 @@ The only supported cipher is ``chacha20_poly1305`` (so far), or ``none``.
 When kdfname is none, so should the ciphername be (and vice-versa), and the ``(rounds || salt)`` string is not included. This is used when the key material is not encrypted.
 
 In case the key material is encrypted, the KDF is used to derive a secret from a user-supplied passphrase.
-A nonce is randomly generated, and used in conjonction with the secret to encrypt the private key, using Chacha20 and authenticated with Poly1305. The nonce is prepended to the encrypted data.
+A nonce is randomly generated, and used in conjunction with the secret to encrypt the private key, using Chacha20 and authenticated with Poly1305. The nonce is prepended to the encrypted data.
 
 Finally, an optional comment can be used at the end of the encoded format.

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ We use the testfile and Bob encrypts it for himself.
       Expected outcome: Alice reads one "a", 65536 "b"s and one "c".
 
 - [x] Bob sends the secret message `Let's have beers in the sauna! or Dinner at 7pm?` to Alice.
-      The message is burried in the middle of some random data.
+      The message is buried in the middle of some random data.
       Alice decrypts what she receives
       Expected outcome: Alice reads `Let's have beers in the sauna! or Dinner at 7pm?`.
 

--- a/tests/edit_list.bats
+++ b/tests/edit_list.bats
@@ -14,7 +14,7 @@ function teardown() {
     rm -rf ${TESTFILES}
 }
 
-@test "Bob sends a secret message to Alice, burried in some random data" {
+@test "Bob sends a secret message to Alice, buried in some random data" {
 
     # Original message
     echo -n "Let's have beers in the sauna! or Dinner at 7pm?" > $TESTFILES/message.bob


### PR DESCRIPTION
Fix small typos and add more descriptive message for `scrypt` support