### PR TITLE
generate private key before public key

### DIFF
--- a/crypt4gh/keys/c4gh.py
+++ b/crypt4gh/keys/c4gh.py
@@ -67,15 +67,6 @@ def generate(seckey, pubkey, passphrase=None, comment=None):
     sk = PrivateKey.generate()
     LOG.debug('Private Key: %s', bytes(sk).hex().upper())
 
-    os.umask(0o133) # Restrict to rw- r-- r--
-
-    with open(pubkey, 'bw', ) as f:
-        f.write(b'-----BEGIN CRYPT4GH PUBLIC KEY-----\n')
-        pkey = bytes(sk.public_key)
-        LOG.debug('Public Key: %s', pkey.hex().upper())
-        f.write(b64encode(pkey))
-        f.write(b'\n-----END CRYPT4GH PUBLIC KEY-----\n')
-
     os.umask(0o277) # Restrict to r-- --- ---
 
     # open the file
@@ -86,6 +77,15 @@ def generate(seckey, pubkey, passphrase=None, comment=None):
         f.write(b'-----BEGIN CRYPT4GH PRIVATE KEY-----\n')
         f.write(b64encode(pkey))
         f.write(b'\n-----END CRYPT4GH PRIVATE KEY-----\n')
+
+    os.umask(0o133) # Restrict to rw- r-- r--
+
+    with open(pubkey, 'bw', ) as f:
+        f.write(b'-----BEGIN CRYPT4GH PUBLIC KEY-----\n')
+        pkey = bytes(sk.public_key)
+        LOG.debug('Public Key: %s', pkey.hex().upper())
+        f.write(b64encode(pkey))
+        f.write(b'\n-----END CRYPT4GH PUBLIC KEY-----\n')
 
 
 #######################################################################


### PR DESCRIPTION
# Problem
Key pair can become mismatched if keys are generated twice, because the private key is write protected, but the public key is not. What happens with calling `c4gh.generate()` twice, is the first key pair is generated, and then during the generation of the second key pair, the original private key stays the same, but the public key is overwritten with a new key that no longer matches the private key that didn't change.

The problem was encountered, when a user had forgotten their private key password, and they generated a new key pair, but they didn't remove the old keys before generating new ones.

# Reproduction
Generate key pair twice with `c4gh.generate()`

# Solution
̃~Make public key to be write protected similarly to the private key, so that the key pair doesn't get accidentally mismatched, if trying to generate new keys, while there are existing keys in the same directory.~

Generate private key before public key, similarly to OpenSSH conventions, as per https://github.com/EGA-archive/crypt4gh/pull/30#issuecomment-1171089414