### PR TITLE
error if a public key does not exist

### DIFF
--- a/crypt4gh/cli.py
+++ b/crypt4gh/cli.py
@@ -134,7 +134,8 @@ def encrypt(args):
         for pk in args['--recipient_pk']:
             recipient_pubkey = os.path.expanduser(pk)
             if not os.path.exists(recipient_pubkey):
-                continue
+                msg = f"Recipient pubkey: {recipient_pubkey}, does not exist"
+                raise ValueError(msg)
             LOG.debug("Recipient pubkey: %s", recipient_pubkey)
             yield (0, seckey, get_public_key(recipient_pubkey))
 
@@ -195,7 +196,8 @@ def reencrypt(args):
         for pk in args['--recipient_pk']:
             recipient_pubkey = os.path.expanduser(pk)
             if not os.path.exists(recipient_pubkey):
-                continue
+                msg = f"Recipient pubkey: {recipient_pubkey}, does not exist"
+                raise ValueError(msg)
             LOG.debug("Recipient pubkey: %s", recipient_pubkey)
             yield (0, seckey, get_public_key(recipient_pubkey))
 

--- a/crypt4gh/cli.py
+++ b/crypt4gh/cli.py
@@ -134,8 +134,8 @@ def encrypt(args):
         for pk in args['--recipient_pk']:
             recipient_pubkey = os.path.expanduser(pk)
             if not os.path.exists(recipient_pubkey):
-                msg = f"Recipient pubkey: {recipient_pubkey}, does not exist"
-                raise ValueError(msg)
+                print(f"Recipient pubkey: {recipient_pubkey}, does not exist", file=sys.stderr)
+                continue
             LOG.debug("Recipient pubkey: %s", recipient_pubkey)
             yield (0, seckey, get_public_key(recipient_pubkey))
 
@@ -196,8 +196,8 @@ def reencrypt(args):
         for pk in args['--recipient_pk']:
             recipient_pubkey = os.path.expanduser(pk)
             if not os.path.exists(recipient_pubkey):
-                msg = f"Recipient pubkey: {recipient_pubkey}, does not exist"
-                raise ValueError(msg)
+                print(f"Recipient pubkey: {recipient_pubkey}, does not exist", file=sys.stderr)
+                continue
             LOG.debug("Recipient pubkey: %s", recipient_pubkey)
             yield (0, seckey, get_public_key(recipient_pubkey))
 


### PR DESCRIPTION
closes #32 

I think it is ok to error if a public key does not exist, as it is the user's expectation to use that key, and if it does not exist and we don't error they would assume all went well and that a header is encrypted with more than 1 key