### PR TITLE
remove python 3.6 github actions

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
python 3.6 not available any more in github actions thus we remove it

@silverdaz this should fix github action