### PR TITLE
Switch to docopt-ng

### DIFF
--- a/crypt4gh/cli.py
+++ b/crypt4gh/cli.py
@@ -58,7 +58,7 @@ Environment variables:
 def parse_args(argv=sys.argv[1:]):
 
     version = f'{__title__} (version {__version__})'
-    args = docopt(__doc__, argv, help=True, version=version)
+    args = docopt(__doc__, argv, version=version)
 
     # if args['version']: print(version); sys.exit(0)
     # if args['help']: print(__doc__.strip()); sys.exit(0)

--- a/crypt4gh/debug.py
+++ b/crypt4gh/debug.py
@@ -54,7 +54,7 @@ Environment variables:
 def parse_args(argv=sys.argv[1:]):
 
     version = f'{__title__} (version {__version__})'
-    args = docopt(__doc__, argv, help=True, version=version)
+    args = docopt(__doc__, argv, version=version)
 
     # if args['version']: print(version); sys.exit(0)
     # if args['help']: print(__doc__.strip()); sys.exit(0)

--- a/crypt4gh/keys/__init__.py
+++ b/crypt4gh/keys/__init__.py
@@ -140,7 +140,7 @@ def run(argv=sys.argv[1:]):
 
     # Parse CLI arguments
     version = f'{__title__} (version {__version__})'
-    args = docopt(__doc__, argv, help=True, version=version)
+    args = docopt(__doc__, argv, version=version)
 
     # Logging
     logger = args['--log'] or DEFAULT_LOG

--- a/crypt4gh/keys/debug.py
+++ b/crypt4gh/keys/debug.py
@@ -36,7 +36,7 @@ def main(argv=sys.argv[1:]):
 
     # Parse CLI arguments
     version = f'{__title__} (version {__version__})'
-    args = docopt(__doc__, argv, help=True, version=version)
+    args = docopt(__doc__, argv, version=version)
 
     # Logging
     d = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyYaml
-docopt
+docopt-ng
 cryptography
 pynacl
 bcrypt

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='crypt4gh',
       # See https://packaging.python.org/discussions/install-requires-vs-requirements/
       install_requires=[
           'pyYaml>=5.1.2',
-          'docopt', # include version when needed
+          'docopt-ng', # include version when needed
           'cryptography>=2.8',
           'pynacl>=1.3.0',
           'bcrypt', # include version when needed


### PR DESCRIPTION
docopt is abandoned, switch to the maintained docopt-ng package.

Fixes #37.

The `help` argument was replaced by `default_help`, but it defaults to `True` anyway (in both docopt and docopt-ng), so I just removed it.

Testing:

```
❯ crypt4gh --help
Utility for the cryptographic GA4GH standard, reading from stdin and outputting to stdout.

Usage:
   crypt4gh [-hv] [--log <file>] encrypt [--sk <path>] --recipient_pk <path> [--recipient_pk <path>]... [--range <start-end>] [--header <path>]
   crypt4gh [-hv] [--log <file>] decrypt [--sk <path>] [--sender_pk <path>] [--range <start-end>]
   crypt4gh [-hv] [--log <file>] rearrange [--sk <path>] --range <start-end>
   crypt4gh [-hv] [--log <file>] reencrypt [--sk <path>] --recipient_pk <path> [--recipient_pk <path>]... [--trim] [--header-only]

Options:
   -h, --help             Prints this help and exit
   -v, --version          Prints the version and exits
   --log <file>           Path to the logger file (in YML format)
   --sk <keyfile>         Curve25519-based Private key
                          When encrypting, if neither the private key nor C4GH_SECRET_KEY are specified, we generate a new key
   --recipient_pk <path>  Recipient's Curve25519-based Public key
   --sender_pk <path>     Peer's Curve25519-based Public key to verify provenance (akin to signature)
   --range <start-end>    Byte-range either as  <start-end> or just <start> (Start included, End excluded)
   -t, --trim             Keep only header packets that you can decrypt
   --header <path>        Where to write the header (default: stdout)
   --header-only          Whether the input data consists only of a header (default: false)

Environment variables:
   C4GH_LOG         If defined, it will be used as the default logger
   C4GH_SECRET_KEY  If defined, it will be used as the default secret key (ie --sk ${C4GH_SECRET_KEY})
   C4GH_PASSPHRASE  If defined, it will be used as the passphrase
                    for decoding the secret key, replacing the callback.
                    Note: this is insecure. Only used for testing
   C4GH_DEBUG       If True, it will print (a lot of) debug information.
                    (Watch out: the output contains secrets)
```

```
❯ python -m crypt4gh.keys --help

Utility to create Crypt4GH-formatted keys.

Usage:
   crypt4gh-keygen [-hv] [--log <file>] [-f] [--pk <path>] [--sk <path>] [--nocrypt] [-C <comment>] [--relock]

Options:
   -h, --help             Prints this help and exit
   -v, --version          Prints the version and exits
   --log <file>           Path to the logger file (in YML format)
   --sk <keyfile>         Curve25519-based Private key [default: ~/.c4gh/key]
   --pk <keyfile>         Curve25519-based Public key  [default: ~/.c4gh/key.pub]
   -C <comment>           Key's Comment
   --nocrypt              Do not encrypt the private key.
                          Otherwise it is encrypted in the Crypt4GH key format
                          (See https://crypt4gh.readthedocs.io/en/latest/keys.html)
   -f                     Overwrite the destination files
   --relock               Re-lock the private key with a new passphrase


Environment variables:
  +-------------------+--------------------------------------------------------------------------------------+
  | C4GH_LOG          | If defined, it will be used as the default logger                                    |
  +-------------------+--------------------------------------------------------------------------------------+
  | C4GH_PUBLIC_KEY   | If defined, it will be used as the default public key (ie --pk ${C4GH_PUBLIC_KEY})   |
  +-------------------+--------------------------------------------------------------------------------------+
  | C4GH_SECRET_KEY   | If defined, it will be used as the default secret key (ie --sk ${C4GH_SECRET_KEY})   |
  +-------------------+--------------------------------------------------------------------------------------+
```

```
❯ python -m crypt4gh.debug --help

Utility for the cryptographic GA4GH standard, reading from stdin.

This is only used for debugging

Usage:
   crypt4gh-debug [-hv] [--log <file>] [--sk <path>] [--sender_pk <path>]

Options:
   -h, --help             Prints this help and exit
   -v, --version          Prints the version and exits
   --log <file>           Path to the logger file (in YML format)
   --sk <keyfile>         Curve25519-based Private key [default: ~/.c4gh/key]
   --sender_pk <path>     Peer's Curve25519-based Public key to verify provenance (aka, signature)


Environment variables:
   C4GH_LOG         If defined, it will be used as the default logger
   C4GH_SECRET_KEY  If defined, it will be used as the default secret key (ie --sk ${C4GH_SECRET_KEY})
```