### PR TITLE
C extension

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -9,21 +9,61 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repository (with libsodium submodule)
+      uses: actions/checkout@v5
+      with:
+        submodules: recursive
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install -e .
+
+    - name: Install package
+      run: pip install .
+
+    - name: Save Python environment
+      run: |
+        tar -czf python-env.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])') .
+    - name: Upload environment artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: python-env
+        path: python-env.tar.gz
+
+
+  tests:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 6
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Restore Python environment
+      run: |
+        tar -xzf /tmp/python-env/python-env.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])')
+
+    - name: Install Bats
+      run: |
         git clone https://github.com/bats-core/bats-core.git
         pushd bats-core && git checkout v1.1.0 && sudo ./install.sh /usr/local && popd
-    - name: Test with bats
+
+    - name: Run bats tests
       run: |
         bats tests

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -48,8 +48,8 @@ jobs:
     - name: Install Crypt4GH with system-wide libsodium (Ubuntu)
       if: matrix.os == 'ubuntu-latest' && matrix.install == 'system'
       run: |
-        apt-get update
-        apt-get install -y pkg-config libsodium-dev
+        sudo apt-get update
+        sudo apt-get install -y pkg-config libsodium-dev
         export SODIUM_INSTALL=system
         export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)"
         export LDFLAGS="$(pkg-config --libs libsodium)"
@@ -68,7 +68,7 @@ jobs:
     - name: Install bats (Ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        apt-get install -y bats
+        sudo apt-get install -y bats
 
     - name: Run tests
       run: |

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -51,8 +51,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y pkg-config libsodium-dev
         export SODIUM_INSTALL=system
+        export CFLAGS="$(pkg-config --cflags libsodium)"
         export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)"
-        export LDFLAGS="$(pkg-config --libs libsodium)"
         pip install . --no-cache-dir
 
     - name: Install package (bundled)

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -9,6 +9,7 @@ jobs:
 
     strategy:
       max-parallel: 6
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -5,11 +5,12 @@ on: [push]
 jobs:
 
   build:
-    runs-on: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
 
     strategy:
       max-parallel: 6
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
@@ -33,20 +34,20 @@ jobs:
 
     - name: Save Python environment
       run: |
-        tar -czf python-env.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])') .
+        tar -czf python-env-${{ matrix.os }}.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])') .
     - name: Upload environment artifact
       uses: actions/upload-artifact@v6
       with:
-        name: python-env
-        path: python-env.tar.gz
-
+        name: python-env-${{ matrix.os }}
+        path: python-env-${{ matrix.os }}.tar.gz
 
   tests:
     needs: build
-    runs-on: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 6
       matrix:
+        os: [macos-latest, ubuntu-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
@@ -55,9 +56,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Download Python environment artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: python-env-${{ matrix.os }}
+        path: /tmp
+
     - name: Restore Python environment
       run: |
-        tar -xzf /tmp/python-env/python-env.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])')
+        tar -xzf /tmp/python-env-${{ matrix.os }}.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])')
 
     - name: Install Bats
       run: |

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Install pkg-config and libsodium (macOS)
       if: matrix.os == 'macos-latest'
       run: |
-        brew install pkg-config libsodium
+        brew install pkg-config libsodium bash
 
     - name: Install pkg-config and libsodium (Ubuntu)
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -80,7 +80,11 @@ jobs:
       run: |
         export SODIUM_INSTALL=system
         export CFLAGS="$(pkg-config --cflags libsodium)"
-        export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)"
+        if [ "$RUNNER_OS" = "Linux" ]; then
+            export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)"
+        else
+            export LDFLAGS="$(pkg-config --libs libsodium)"
+        fi
         pip install . --no-cache-dir
 
     - name: Install Bats

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -11,53 +11,18 @@ jobs:
       max-parallel: 6
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        install: ['system', 'bundled']
 
     steps:
     - name: Checkout repository (with libsodium submodule)
+      if: matrix.install == 'bundled'
       uses: actions/checkout@v6
       with:
         submodules: recursive
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-
-    - name: Install package
-      run: |
-        pip install . --no-cache-dir
-
-    - name: Install newer bash for macOS
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install bash
-
-    - name: Install Bats
-      run: |
-        git clone https://github.com/bats-core/bats-core.git
-        pushd bats-core && git checkout v1.1.0 && sudo ./install.sh /usr/local && popd
-
-    - name: Run bats tests
-      run: |
-        bats tests
-
-
-  build-system:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      max-parallel: 6
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
-
-    steps:
-    - name: Checkout repository (without libsodium submodule)
+    - name: Checkout repository (with system-wide libsodium)
+      if: matrix.install != 'bundled'
       uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -65,38 +30,45 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Install pkg-config and libsodium (macOS)
-      if: matrix.os == 'macos-latest'
+    - name: Install Crypt4GH with system-wide libsodium (macOS)
+      if: matrix.os == 'macos-latest' && matrix.install == 'system'
       run: |
-        brew install pkg-config libsodium bash
-
-    - name: Install pkg-config and libsodium (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y pkg-config libsodium-dev
-
-    - name: Install package with system-wide libsodium
-      run: |
+        brew install pkg-config libsodium
         export SODIUM_INSTALL=system
         export CFLAGS="$(pkg-config --cflags libsodium)"
-        if [ "$RUNNER_OS" = "Linux" ]; then
-            export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)"
-        else
-            export LDFLAGS="$(pkg-config --libs libsodium)"
-        fi
+        export LDFLAGS="$(pkg-config --libs libsodium)"
         pip install . --no-cache-dir
 
-    - name: Install Bats
+    - name: Install Crypt4GH with system-wide libsodium (Ubuntu)
+      if: matrix.os == 'ubuntu-latest' && matrix.install == 'system'
       run: |
-        git clone https://github.com/bats-core/bats-core.git
-        pushd bats-core && git checkout v1.1.0 && sudo ./install.sh /usr/local && popd
+        apt-get update
+        apt-get install -y pkg-config libsodium-dev
+        export SODIUM_INSTALL=system
+        export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)"
+        export LDFLAGS="$(pkg-config --libs libsodium)"
+        pip install . --no-cache-dir
 
-    - name: Run bats tests
+    - name: Install package (bundled)
+      if: matrix.install != 'system'
+      run: |
+        pip install . --no-cache-dir
+
+    - name: Install bats (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install bash bats-core
+
+    - name: Install bats (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        apt-get install -y bats
+
+    - name: Run tests
       run: |
         bats tests

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -33,6 +33,11 @@ jobs:
       run: |
         pip install . --no-cache-dir
 
+    - name: Install newer bash for macOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install bash
+
     - name: Install Bats
       run: |
         git clone https://github.com/bats-core/bats-core.git

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         install: ['system', 'bundled']
 
     steps:

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -3,9 +3,10 @@ name: Testsuite
 on: [push]
 
 jobs:
-  build:
 
-    runs-on: ubuntu-latest
+  build:
+    runs-on: [macos-latest, ubuntu-latest]
+
     strategy:
       max-parallel: 6
       matrix:
@@ -13,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repository (with libsodium submodule)
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -42,14 +43,13 @@ jobs:
 
   tests:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [macos-latest, ubuntu-latest]
     strategy:
       max-parallel: 6
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -67,3 +67,4 @@ jobs:
     - name: Run bats tests
       run: |
         bats tests
+

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -30,41 +30,8 @@ jobs:
         pip install -r requirements.txt
 
     - name: Install package
-      run: pip install .
-
-    - name: Save Python environment
       run: |
-        tar -czf python-env-${{ matrix.os }}.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])') .
-    - name: Upload environment artifact
-      uses: actions/upload-artifact@v6
-      with:
-        name: python-env-${{ matrix.os }}
-        path: python-env-${{ matrix.os }}.tar.gz
-
-  tests:
-    needs: build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      max-parallel: 6
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
-
-    steps:
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Download Python environment artifact
-      uses: actions/download-artifact@v6
-      with:
-        name: python-env-${{ matrix.os }}
-        path: /tmp
-
-    - name: Restore Python environment
-      run: |
-        tar -xzf /tmp/python-env-${{ matrix.os }}.tar.gz -C $(python -c 'import site; print(site.getsitepackages()[0])')
+        pip install . --no-cache-dir
 
     - name: Install Bats
       run: |
@@ -75,3 +42,52 @@ jobs:
       run: |
         bats tests
 
+
+  build-system:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 6
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+
+    steps:
+    - name: Checkout repository (without libsodium submodule)
+      uses: actions/checkout@v6
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install pkg-config and libsodium (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install pkg-config libsodium
+
+    - name: Install pkg-config and libsodium (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y pkg-config libsodium-dev
+
+    - name: Install package with system-wide libsodium
+      run: |
+        export SODIUM_INSTALL=system
+        export CFLAGS="$(pkg-config --cflags libsodium)"
+        export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)"
+        pip install . --no-cache-dir
+
+    - name: Install Bats
+      run: |
+        git clone https://github.com/bats-core/bats-core.git
+        pushd bats-core && git checkout v1.1.0 && sudo ./install.sh /usr/local && popd
+
+    - name: Run bats tests
+      run: |
+        bats tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ private/
 _build/
 logger*.yaml
 
+libsodium-build
+
+crypt4gh/sodium.*
+!crypt4gh/sodium.c
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libsodium-stable"]
+	path = libsodium-stable
+	url = https://github.com/jedisct1/libsodium.git
+	branch = stable

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ pip install crypt4gh
 or [compile and install it from the latest sources](#compilation-from-sources)
 
 
-See [notes on compilation](#compilation)
-
 ## Usage
 
 The usual `-h` flag shows you the different options that the tool accepts.

--- a/README.md
+++ b/README.md
@@ -16,19 +16,10 @@ Install it from PyPI:
 pip install crypt4gh
 ```
 
-or if you prefer the latest sources from Github:
+or [compile and install it from the latest sources](#compilation-from-sources)
 
-```
-git clone https://github.com/EGA-archive/crypt4gh
-pip install -r crypt4gh/requirements.txt
-pip install ./crypt4gh
-```
 
-or
-
-```
-pip install git+https://github.com/EGA-archive/crypt4gh.git
-```
+See [notes on compilation](#compilation)
 
 ## Usage
 
@@ -91,3 +82,35 @@ $ crypt4gh decrypt --sk alice.sec < file.c4gh
 ## File Format
 
 Refer to the [specifications](http://samtools.github.io/hts-specs/crypt4gh.pdf) or this [documentation](https://crypt4gh.readthedocs.io/en/latest/encryption.html).
+
+## Compilation from sources
+
+Get the source code, and install the python dependencies with:
+
+```
+git clone --recursive https://github.com/EGA-archive/crypt4gh
+pip install -r crypt4gh/requirements.txt
+```
+
+The Crypt4GH python package relies on
+[libsodium](https://libsodium.org), a portable C library. A copy is
+bundled with Crypt4GH as a submodule. You can either use the version
+of libsodium already installed on your system (eg, provided by your
+distribution), or use the bundled version.
+
+For the system-wide version, you use the `SODIUM_INSTALL=system` environment variable. You might also need to adjust the `CFLAGS` and `LDFLAGS` environment variables. For example, using `pkg-config` to find the libsodium headers and library, you can use:
+
+```
+export SODIUM_INSTALL=system
+# If not installed in default locations
+export CFLAGS="$(pkg-config --cflags libsodium)"
+export LDFLAGS="$(pkg-config --libs libsodium)"
+```
+
+If you want to use the bundled version, skip those environment variables.
+
+Finally, run
+
+```
+pip install ./crypt4gh
+```

--- a/crypt4gh/__init__.py
+++ b/crypt4gh/__init__.py
@@ -53,5 +53,6 @@ LOG = logging.getLogger(__name__)
 VERSION = 1
 SEGMENT_SIZE = 65536
 
-
+CIPHER_DIFF = 28 # nonce: 12 + mac: 16 
+CIPHER_SEGMENT_SIZE = SEGMENT_SIZE + CIPHER_DIFF
 

--- a/crypt4gh/__init__.py
+++ b/crypt4gh/__init__.py
@@ -37,9 +37,9 @@ cryptographic file format."""
 
 
 __title__ = 'GA4GH cryptographic utilities'
-__version__ = '1.7' # VERSION in header is 1 (as 4 bytes little endian)
+__version__ = '1.8' # VERSION in header is 1 (as 4 bytes little endian)
 __author__ = 'Frédéric Haziza'
-__author_email__ = 'frederic.haziza@crg.eu'
+__author_email__ = 'silverdaz@gmail.com'
 __license__ = 'Apache License 2.0'
 __copyright__ = __title__ + ' @ CRG'
 

--- a/crypt4gh/cli.py
+++ b/crypt4gh/cli.py
@@ -9,10 +9,9 @@ from getpass import getpass
 import re
 
 from docopt import docopt
-from nacl.public import PrivateKey
 
 from . import __title__, __version__, PROG
-from . import lib
+from . import lib, sodium
 from .keys import get_public_key, get_private_key
 
 LOG = logging.getLogger(__name__)
@@ -105,8 +104,7 @@ def retrieve_private_key(args, generate=False):
     seckey = args['--sk'] or DEFAULT_SK
 
     if generate and seckey is None: # generate a one on the fly
-        sk = PrivateKey.generate()
-        skey = bytes(sk)
+        skey = os.urandom(32)
         LOG.debug('Generating Private Key: %s', skey.hex().upper())
         return skey
 
@@ -188,8 +186,9 @@ def rearrange(args):
     range_start, range_span = parse_range(args)
 
     seckey = retrieve_private_key(args)
+    pubkey = sodium.derive_pk(seckey)
 
-    keys = [(0, seckey, bytes(PrivateKey(seckey).public_key))] # keys = list of (method, privkey, recipient_pubkey=ourselves)
+    keys = [(0, seckey, pubkey)] # keys = list of (method, privkey, recipient_pubkey=ourselves)
 
     lib.rearrange(keys,
                   sys.stdin.buffer,

--- a/crypt4gh/cli.py
+++ b/crypt4gh/cli.py
@@ -3,10 +3,11 @@
 import sys
 import os
 import logging
-import logging.config
+from logging.config import dictConfig
 from functools import partial
 from getpass import getpass
 import re
+import json
 
 from docopt import docopt
 
@@ -59,19 +60,15 @@ def parse_args(argv=sys.argv[1:]):
     version = f'{__title__} (version {__version__})'
     args = docopt(__doc__, argv, version=version)
 
-    # if args['version']: print(version); sys.exit(0)
-    # if args['help']: print(__doc__.strip()); sys.exit(0)
-
-    # Logging
-    logger = args['--log'] or DEFAULT_LOG
-    # for the root logger
+    # Logging for the root logger
     logging.basicConfig(stream=sys.stderr,
                         level=logging.DEBUG if C4GH_DEBUG else logging.CRITICAL,
                         format='[%(levelname)s] %(message)s')
+
+    logger = args['--log'] or DEFAULT_LOG
     if logger and os.path.exists(logger):
         with open(logger, 'rt') as stream:
-            import yaml
-            logging.config.dictConfig(yaml.safe_load(stream))
+            dictConfig(json.load(stream))
 
     # I prefer to clean up
     for s in ['--log', '--help', '--version']:#, 'help', 'version']:

--- a/crypt4gh/debug.py
+++ b/crypt4gh/debug.py
@@ -4,10 +4,11 @@
 import sys
 import os
 import logging
-import logging.config
+from logging.config import dictConfig
 from functools import partial
 from getpass import getpass
 #import traceback
+import json
 
 from docopt import docopt
 
@@ -56,16 +57,12 @@ def parse_args(argv=sys.argv[1:]):
     version = f'{__title__} (version {__version__})'
     args = docopt(__doc__, argv, version=version)
 
-    # if args['version']: print(version); sys.exit(0)
-    # if args['help']: print(__doc__.strip()); sys.exit(0)
-
     # Logging
     logger = args['--log'] or DEFAULT_LOG
-    logging.basicConfig(stream=sys.stderr, level=logging.CRITICAL) # for the root logger
+    logging.basicConfig(stream=sys.stderr, level=logging.DEBUG) # for the root logger
     if logger and os.path.exists(logger):
         with open(logger, 'rt') as stream:
-            import yaml
-            logging.config.dictConfig(yaml.safe_load(stream))
+            dictConfig(json.load(stream))
 
     # I prefer to clean up
     for s in ['--log', '--help', '--version']:#, 'help', 'version']:

--- a/crypt4gh/exceptions.py
+++ b/crypt4gh/exceptions.py
@@ -8,20 +8,8 @@ import sys
 import logging
 import errno
 
-from nacl.exceptions import (InvalidkeyError,
-                             BadSignatureError,
-                             CryptoError)
-
 LOG = logging.getLogger(__name__)
 
-def convert_error(func):
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except (InvalidkeyError, BadSignatureError, CryptoError) as e:
-            LOG.error('Converting Crypto errors')
-            raise ValueError('Crypt4GH Crypto Error') from e
-    return wrapper
 
 def close_on_broken_pipe(func):
     def wrapper(*args, **kwargs):
@@ -37,7 +25,7 @@ def exit_on_invalid_passphrase(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except CryptoError as e:
+        except Exception as e:
             LOG.error('Exiting for %r', e)
             print('Invalid Key or Passphrase', file=sys.stderr)
             sys.exit(2)

--- a/crypt4gh/header.py
+++ b/crypt4gh/header.py
@@ -6,14 +6,7 @@ import logging
 from itertools import chain
 # from types import GeneratorType
 
-from nacl.bindings import (crypto_kx_client_session_keys,
-                           crypto_kx_server_session_keys,
-                           crypto_aead_chacha20poly1305_ietf_encrypt,
-                           crypto_aead_chacha20poly1305_ietf_decrypt)
-from nacl.exceptions import CryptoError
-from nacl.public import PrivateKey
-
-from . import SEGMENT_SIZE, VERSION
+from . import sodium, SEGMENT_SIZE, VERSION, CIPHER_DIFF
 
 LOG = logging.getLogger(__name__)
 
@@ -171,7 +164,7 @@ def parse_edit_list_packet(packet):
 def encrypt_X25519_Chacha20_Poly1305(data, seckey, recipient_pubkey):
     '''Computes the encrypted part'''
 
-    pubkey = bytes(PrivateKey(seckey).public_key)
+    pubkey = sodium.derive_pk(seckey)
 
     #LOG.debug('Original data: %s', data.hex())
     LOG.debug("         Packet data: %s", data.hex())
@@ -180,13 +173,14 @@ def encrypt_X25519_Chacha20_Poly1305(data, seckey, recipient_pubkey):
     LOG.debug('recipient public key: %s', recipient_pubkey.hex())
 
     # X25519 shared key
-    _, shared_key = crypto_kx_server_session_keys(pubkey, seckey, recipient_pubkey)
+    shared_key = sodium.kx_server(pubkey, seckey, recipient_pubkey)
     LOG.debug('shared key: %s', shared_key.hex())
 
-    # Chacha20_Poly1305
-    nonce = os.urandom(12)
-    encrypted_data = crypto_aead_chacha20poly1305_ietf_encrypt(data, None, nonce, shared_key)  # no add
-    return (pubkey + nonce + encrypted_data)
+    encrypted_data = bytearray(len(data) + CIPHER_DIFF)
+
+    # Chacha20_Poly1305 (including nonce)
+    clen = sodium.chacha20poly1305_encrypt(encrypted_data, data, shared_key)
+    return pubkey + encrypted_data[:clen]
 
 def decrypt_X25519_Chacha20_Poly1305(encrypted_part, privkey, sender_pubkey=None):
     #LOG.debug('-----------  Encrypted data: %s', encrypted_part.hex())
@@ -205,12 +199,13 @@ def decrypt_X25519_Chacha20_Poly1305(encrypted_part, privkey, sender_pubkey=None
     LOG.debug('encrypted data: %s', packet_data.hex())
 
     # X25519 shared key
-    pubkey = bytes(PrivateKey(privkey).public_key)  # slightly inefficient, but working
-    shared_key, _ = crypto_kx_client_session_keys(pubkey, privkey, peer_pubkey)
+    pubkey = sodium.derive_pk(privkey)
+    shared_key = sodium.kx_client(pubkey, privkey, peer_pubkey)
     LOG.debug('shared key: %s', shared_key.hex())
 
-    # Chacha20_Poly1305
-    return crypto_aead_chacha20poly1305_ietf_decrypt(packet_data, None, nonce, shared_key)  # no add
+    decrypted_data = bytearray(len(packet_data)) # larger then needed
+    plen = sodium.chacha20poly1305_decrypt(decrypted_data, encrypted_part[32:], shared_key)
+    return decrypted_data[:plen]
 
 
 def decrypt_packet(packet, keys, sender_pubkey=None):
@@ -232,10 +227,8 @@ def decrypt_packet(packet, keys, sender_pubkey=None):
             try:
                 privkey, _ = key # must fit
                 return decrypt_X25519_Chacha20_Poly1305(packet[4:], privkey, sender_pubkey=sender_pubkey)
-            except CryptoError as tag:
-                LOG.error('Packet Decryption failed: %s', tag)
-            except Exception as e: # Any other error, like (IndexError, TypeError, ValueError)
-                LOG.error('Not a X25519 key: ignoring | %s', e)
+            except Exception as e:
+                LOG.error('X25519 Packet Decryption failed: %s', e)
                 # try the next one
 
         elif packet_encryption_method == 1:

--- a/crypt4gh/keys/__init__.py
+++ b/crypt4gh/keys/__init__.py
@@ -6,10 +6,11 @@ import sys
 import os
 import io
 import logging
-import logging.config
+from logging.config import dictConfig
 from base64 import b64decode, b64encode
 from functools import partial
 from getpass import getpass
+import json
 
 from docopt import docopt
 
@@ -146,8 +147,7 @@ def run(argv=sys.argv[1:]):
     logger = args['--log'] or DEFAULT_LOG
     if logger and os.path.exists(logger):
         with open(logger, 'rt') as stream:
-            import yaml
-            logging.config.dictConfig(yaml.safe_load(stream))
+            dictConfig(json.load(stream))
 
     # I prefer to clean up
     for s in ['--log', '--help', '--version']:#, 'help', 'version']:

--- a/crypt4gh/keys/c4gh.py
+++ b/crypt4gh/keys/c4gh.py
@@ -3,7 +3,6 @@ import os
 import sys
 from base64 import b64encode
 
-from nacl.public import PrivateKey
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
 
 from .kdf import derive_key, get_kdf, scrypt_supported, KDFS
@@ -64,8 +63,8 @@ def generate(seckey, pubkey, passphrase=None, comment=None):
     '''Generate a keypair.'''
 
     # Generate the keys
-    sk = PrivateKey.generate()
-    LOG.debug('Private Key: %s', bytes(sk).hex().upper())
+    sk = os.urandom(32)
+    LOG.debug('Private Key: %s', sk.hex().upper())
 
     os.umask(0o277) # Restrict to r-- --- ---
 
@@ -82,7 +81,7 @@ def generate(seckey, pubkey, passphrase=None, comment=None):
 
     with open(pubkey, 'bw', ) as f:
         f.write(b'-----BEGIN CRYPT4GH PUBLIC KEY-----\n')
-        pkey = bytes(sk.public_key)
+        pkey = sodium.derive_pk(sk)
         LOG.debug('Public Key: %s', pkey.hex().upper())
         f.write(b64encode(pkey))
         f.write(b'\n-----END CRYPT4GH PUBLIC KEY-----\n')

--- a/crypt4gh/keys/debug.py
+++ b/crypt4gh/keys/debug.py
@@ -78,10 +78,6 @@ def main(argv=sys.argv[1:]):
         cb = partial(getpass, prompt=f'Passphrase for {args["<path>"]}: ')
         seckey = get_private_key(keypath, cb)
         LOG.info('Private Key: %s', seckey.hex().upper())
-
-        # from nacl.public import PrivateKey
-        # sk = PrivateKey(seckey)
-        # assert( pubkey == bytes(sk.public_key) )
         return
 
     raise ValueError('Should not come here')

--- a/crypt4gh/keys/ssh.py
+++ b/crypt4gh/keys/ssh.py
@@ -4,9 +4,8 @@ import io
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
-from nacl.exceptions import CryptoError
-from nacl.bindings.crypto_sign import crypto_sign_ed25519_pk_to_curve25519, crypto_sign_ed25519_sk_to_curve25519
 
+from .. import sodium
 from .kdf import derive_key
 from ..exceptions import exit_on_invalid_passphrase
 
@@ -52,7 +51,7 @@ def get_cipher(ciphername, derived_key):
     key = derived_key[:keylen]
     iv = derived_key[keylen:]
 
-    LOG.debug('Decryptiong Key (%d): %s', len(key), key.hex().upper())
+    LOG.debug('Decryption Key (%d): %s', len(key), key.hex().upper())
     LOG.debug('IV (%d): %s', len(iv), iv.hex().upper())
 
     backend = default_backend()
@@ -89,7 +88,7 @@ def _get_skpk_from_decrypted_private_blob(blob):
     checkint2 = blob.read(4)
     if checkint1 != checkint2:
         LOG.error('Check: %s != %s', checkint1, checkint2)
-        raise CryptoError()
+        raise ValueError()
 
     # We should parse n keys, but n is 1
     decode_string(blob) # ignore key name
@@ -104,10 +103,10 @@ def _get_skpk_from_decrypted_private_blob(blob):
     pk = skpk[32:] # second half = pub key
     LOG.debug('ed25519 pk: %s', pk.hex().upper())
 
-    seckey = crypto_sign_ed25519_sk_to_curve25519(skpk)
+    seckey = sodium.sign_ed25519_sk_to_curve25519(skpk)
     LOG.debug('x25519 sk: %s', seckey.hex().upper())
 
-    pubkey = crypto_sign_ed25519_pk_to_curve25519(pk)
+    pubkey = sodium.sign_ed25519_pk_to_curve25519(pk)
     LOG.debug('x25519 pk: %s', pubkey.hex().upper())
 
     return (seckey, pubkey)
@@ -169,7 +168,7 @@ def parse_private_key(stream, callback):
     dklen = get_derived_key_length(ciphername) # key length + IV length
     LOG.debug('Derived Key len: %d', dklen)
     derived_key = derive_key(kdfname, passphrase, salt, rounds, dklen=dklen) 
-    LOG.debug('Derived Key: %s', derived_key)
+    LOG.debug('Derived Key: %s', derived_key.hex())
     decryptor = get_cipher(ciphername, derived_key).decryptor()
     assert( len(private_ciphertext) % _block_size(ciphername) == 0 ), "Invalid cipher block length"
     private_data = decryptor.update(private_ciphertext) + decryptor.finalize()
@@ -191,4 +190,4 @@ def get_public_key(line):
     assert( key_type == b'ssh-ed25519' )
     pubkey_bytes = decode_string(stream) # the rest is the ED25519 public key: it should be 32 bytes
     # Converting
-    return crypto_sign_ed25519_pk_to_curve25519(pubkey_bytes)
+    return sodium.sign_ed25519_pk_to_curve25519(pubkey_bytes)

--- a/crypt4gh/lib.py
+++ b/crypt4gh/lib.py
@@ -113,16 +113,6 @@ def encrypt(keys, infile, outfile, headerfile=None, offset=0, span=None):
 #
 ##############################################################
 
-def cipher_chunker(f, size):
-    while True:
-        ciphersegment = f.read(size)
-        ciphersegment_len = len(ciphersegment)
-        if ciphersegment_len == 0: 
-            break # We were at the last segment. Exits the loop
-        assert( ciphersegment_len > CIPHER_DIFF )
-        yield ciphersegment
-
-
 def decrypt_block(segment, ciphersegment, session_keys):
     # Trying the different session keys
     # Note: we could order them and if one fails, we move it at the end of the list
@@ -195,11 +185,17 @@ def body_decrypt(infile, session_keys, output, offset):
 
     try:
         segment = bytearray(SEGMENT_SIZE)
-        for ciphersegment in cipher_chunker(infile, CIPHER_SEGMENT_SIZE):
-            #LOG.debug("Ciphersegment [%d]: %s", len(ciphersegment), ciphersegment.hex())
-            plen = decrypt_block(segment, ciphersegment, session_keys)
-            #LOG.debug("Segment [%d]: %s", plen, segment[:plen].hex())
+        ciphersegment = bytearray(CIPHER_SEGMENT_SIZE)
+
+        while True:
+            ciphersegment_len = infile.readinto(ciphersegment)
+            if ciphersegment_len == 0: 
+                break # We were at the last segment. Exits the loop
+            assert( ciphersegment_len > CIPHER_DIFF )
+
+            plen = decrypt_block(segment, ciphersegment[:ciphersegment_len], session_keys)
             output.send(segment[:plen])
+
     except ProcessingOver:  # output raised it
         pass
 

--- a/crypt4gh/lib.py
+++ b/crypt4gh/lib.py
@@ -196,9 +196,9 @@ def body_decrypt(infile, session_keys, output, offset):
     try:
         segment = bytearray(SEGMENT_SIZE)
         for ciphersegment in cipher_chunker(infile, CIPHER_SEGMENT_SIZE):
-            LOG.debug("Ciphersegment [%d]: %s", len(ciphersegment), ciphersegment.hex())
+            #LOG.debug("Ciphersegment [%d]: %s", len(ciphersegment), ciphersegment.hex())
             plen = decrypt_block(segment, ciphersegment, session_keys)
-            LOG.debug("Segment [%d]: %s", plen, segment[:plen].hex())
+            #LOG.debug("Segment [%d]: %s", plen, segment[:plen].hex())
             output.send(segment[:plen])
     except ProcessingOver:  # output raised it
         pass

--- a/crypt4gh/lib.py
+++ b/crypt4gh/lib.py
@@ -68,8 +68,7 @@ def encrypt(keys, infile, outfile, headerfile=None, offset=0, span=None):
 
     # Preparing the encryption engine
     encryption_method = 0 # only choice for this version
-    #session_key = os.urandom(32) # we use one session key for all blocks
-    session_key = bytes.fromhex('0d4ee5bab2de9a3b250b2e7a96fd3e519ed4979113a00abc2a9b4cd557e6dab6')
+    session_key = os.urandom(32) # we use one session key for all blocks
     LOG.debug("Session key: %s", session_key.hex())
 
     # Output the header

--- a/crypt4gh/lib.py
+++ b/crypt4gh/lib.py
@@ -6,19 +6,14 @@ import logging
 import io
 import collections
 
-from nacl.bindings import (crypto_aead_chacha20poly1305_ietf_encrypt,
-                           crypto_aead_chacha20poly1305_ietf_decrypt)
-from nacl.exceptions import CryptoError
-
-
-from . import SEGMENT_SIZE
+from . import SEGMENT_SIZE, CIPHER_DIFF, CIPHER_SEGMENT_SIZE
 from .exceptions import close_on_broken_pipe
 from . import header
 
+from . import sodium
+
 LOG = logging.getLogger(__name__)
 
-CIPHER_DIFF = 28
-CIPHER_SEGMENT_SIZE = SEGMENT_SIZE + CIPHER_DIFF
 
 # Encryption Methods Conventions
 # ------------------------------
@@ -34,18 +29,7 @@ CIPHER_SEGMENT_SIZE = SEGMENT_SIZE + CIPHER_DIFF
 ##
 ##############################################################
 
-def _encrypt_segment(data, process, key):
-    '''Utility function to generate a nonce, encrypt data with Chacha20, and authenticate it with Poly1305.'''
-
-    #LOG.debug("Segment [%d bytes]: %s..%s", len(data), data[:10], data[-10:])
-
-    nonce = os.urandom(12)
-    encrypted_data = crypto_aead_chacha20poly1305_ietf_encrypt(data, None, nonce, key)  # no add
-    process(nonce) # after producing the segment, so we don't start outputing when an error occurs
-    process(encrypted_data)
-
-
-@close_on_broken_pipe
+#@close_on_broken_pipe
 def encrypt(keys, infile, outfile, headerfile=None, offset=0, span=None):
     '''Encrypt infile into outfile, using the list of keys.
 
@@ -84,7 +68,9 @@ def encrypt(keys, infile, outfile, headerfile=None, offset=0, span=None):
 
     # Preparing the encryption engine
     encryption_method = 0 # only choice for this version
-    session_key = os.urandom(32) # we use one session key for all blocks
+    #session_key = os.urandom(32) # we use one session key for all blocks
+    session_key = bytes.fromhex('0d4ee5bab2de9a3b250b2e7a96fd3e519ed4979113a00abc2a9b4cd557e6dab6')
+    LOG.debug("Session key: %s", session_key.hex())
 
     # Output the header
     LOG.debug('Creating Crypt4GH header')
@@ -97,49 +83,27 @@ def encrypt(keys, infile, outfile, headerfile=None, offset=0, span=None):
 
     # ...and cue music
     LOG.debug("Streaming content")
-    # oh boy... I buffer a whole segment!
-    # TODO: Use a smaller buffer (Requires code rewrite)
+
     segment = bytearray(SEGMENT_SIZE)
+    ciphersegment = bytearray(CIPHER_SEGMENT_SIZE)
 
-    if span is None:
-        # The whole file
-        while True:
-            segment_len = infile.readinto(segment)
+    while span is None or span > 0:
 
-            if segment_len == 0: # finito
-                break
+        segment_len = infile.readinto(segment)
+        if segment_len == 0: # finito
+            break
 
-            if segment_len < SEGMENT_SIZE: # not a full segment
-                data = bytes(segment[:segment_len]) # to discard the bytes from the previous segments
-                _encrypt_segment(data, outfile.write, session_key)
-                break
+        dlen = min(span, segment_len) if span else segment_len
+        clen = sodium.chacha20poly1305_encrypt(ciphersegment, segment[:dlen], session_key)
+        outfile.write(ciphersegment[:clen])
 
-            data = bytes(segment) # this is a full segment
-            _encrypt_segment(data, outfile.write, session_key)
-
-    else: # we have a max size
-        assert( span )
-
-        while span > 0:
-
-            segment_len = infile.readinto(segment)
-
-            data = bytes(segment) # this is a full segment
-
-            if segment_len < SEGMENT_SIZE: # not a full segment
-                data = data[:segment_len] # to discard the bytes from the previous segments
-
+        if span is not None:
             if span < segment_len: # stop early
-                data = data[:span]
-                _encrypt_segment(data, outfile.write, session_key)
                 break
-
-            _encrypt_segment(data, outfile.write, session_key)
-
             span -= segment_len
 
-            if segment_len < SEGMENT_SIZE: # not a full segment
-                break
+        if dlen < SEGMENT_SIZE: # not a full segment
+            break
 
     LOG.info('Encryption Successful')
 
@@ -147,7 +111,7 @@ def encrypt(keys, infile, outfile, headerfile=None, offset=0, span=None):
 ##############################################################
 ##
 ##    Symmetric decryption - Chacha20_Poly1305
-##
+#
 ##############################################################
 
 def cipher_chunker(f, size):
@@ -159,18 +123,16 @@ def cipher_chunker(f, size):
         assert( ciphersegment_len > CIPHER_DIFF )
         yield ciphersegment
 
-def decrypt_block(ciphersegment, session_keys):
-    # Trying the different session keys (via the cipher objects)
+
+def decrypt_block(segment, ciphersegment, session_keys):
+    # Trying the different session keys
     # Note: we could order them and if one fails, we move it at the end of the list
     # So... LRU solution. For now, try them as they come.
-    nonce = ciphersegment[:12]
-    data = ciphersegment[12:]
-
     for key in session_keys:
         try:
-            return crypto_aead_chacha20poly1305_ietf_decrypt(data, None, nonce, key)  # no add, and break the loop
-        except CryptoError as tag:
-            LOG.error('Decryption failed: %s', tag)
+            return sodium.chacha20poly1305_decrypt(segment, ciphersegment, key)
+        except Exception as e:
+            LOG.error('Decryption failed: %s', e)
     else: # no cipher worked: Bark!
         raise ValueError('Could not decrypt that block')
 
@@ -233,9 +195,12 @@ def body_decrypt(infile, session_keys, output, offset):
         infile.seek(start_ciphersegment, io.SEEK_CUR)  # move forward
 
     try:
+        segment = bytearray(SEGMENT_SIZE)
         for ciphersegment in cipher_chunker(infile, CIPHER_SEGMENT_SIZE):
-            segment = decrypt_block(ciphersegment, session_keys)
-            output.send(segment)
+            LOG.debug("Ciphersegment [%d]: %s", len(ciphersegment), ciphersegment.hex())
+            plen = decrypt_block(segment, ciphersegment, session_keys)
+            LOG.debug("Segment [%d]: %s", plen, segment[:plen].hex())
+            output.send(segment[:plen])
     except ProcessingOver:  # output raised it
         pass
 
@@ -247,6 +212,7 @@ class DecryptedBuffer():
         self.buf = io.BytesIO()
         self.block = 0  # just used for printing, if that block is entirely skipped
         self.output = output
+        self.segment = bytearray(SEGMENT_SIZE)
 
     def _append_to_buf(self, data):
         assert( data ), "Why are you adding 'nothing'?"
@@ -281,9 +247,9 @@ class DecryptedBuffer():
         # else, we decrypt
         LOG.debug('Decrypting block %d', self.block)
         assert( len(data) > CIPHER_DIFF )
-        segment = decrypt_block(data, self.session_keys)
-        LOG.debug('Adding %d bytes to the buffer', len(segment))
-        self._append_to_buf(segment)
+        plen = decrypt_block(self.segment, data, self.session_keys)
+        LOG.debug('Adding %d bytes to the buffer', plen)
+        self._append_to_buf(self.segment[:plen])
         LOG.debug('Buffer size: %d', self.buf_size())
         
     def skip(self, size):
@@ -381,6 +347,7 @@ def decrypt(keys, infile, outfile, sender_pubkey=None, offset=0, span=None):
     )
 
     session_keys, edit_list = header.deconstruct(infile, keys, sender_pubkey=sender_pubkey)
+    LOG.debug("Session keys: %s", [k.hex() for k in session_keys])
 
     # Infile in now positioned at the beginning of the data portion
 
@@ -391,7 +358,8 @@ def decrypt(keys, infile, outfile, sender_pubkey=None, offset=0, span=None):
     if edit_list is None:
         # No edit list: decrypt all segments until the end
         body_decrypt(infile, session_keys, output, offset)
-        # We could use body_decrypt_parts but there is an inner buffer, and segments might not be aligned
+        # We could use body_decrypt_parts 
+        # but there is an inner buffer, and segments might not be aligned
     else:
         # Edit list: it drives which segments is decrypted
         body_decrypt_parts(infile, session_keys, output, edit_list=list(edit_list))

--- a/crypt4gh/sodium.c
+++ b/crypt4gh/sodium.c
@@ -126,7 +126,8 @@ crypt4gh_chacha20poly1305_decrypt(PyObject* self, PyObject* args)
     key = (uint8_t *)key_view.buf;
     //key_len = key_view.len;
 
-    if (segment_len < ciphersegment_len - CIPHER_DIFF) {
+    if (ciphersegment_len <= CIPHER_DIFF
+	|| segment_len < ciphersegment_len - CIPHER_DIFF) {
       PyErr_SetString(PyExc_AssertionError, "Invalid buffer sizes");
       goto bailout;
     }

--- a/crypt4gh/sodium.c
+++ b/crypt4gh/sodium.c
@@ -1,0 +1,445 @@
+#include <Python.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <sodium.h>
+
+static char module_name[] = "sodium";
+
+#define NONCE_LEN   12
+#define CIPHER_DIFF 28
+
+static PyObject*
+crypt4gh_chacha20poly1305_encrypt(PyObject* self, PyObject* args)
+{
+    PyObject *ciphersegment_obj, *segment_obj, *key_obj;
+    uint8_t *ciphersegment, *segment, *key;
+    Py_ssize_t ciphersegment_len, segment_len; //, key_len;
+    unsigned long long clen;
+    PyObject* ret;
+    Py_buffer ciphersegment_view, segment_view, key_view;
+
+    memset(&ciphersegment_view, 0, sizeof(ciphersegment_view));
+    memset(&segment_view, 0, sizeof(segment_view));
+    memset(&key_view, 0, sizeof(key_view));
+
+    if (!PyArg_ParseTuple(args, "OOO",
+			  &ciphersegment_obj,
+			  &segment_obj,
+			  &key_obj)) {
+      PyErr_SetString(PyExc_TypeError, "All arguments must be buffer objects");
+      return NULL;
+    }
+
+    ret = NULL;
+
+    if (PyObject_GetBuffer(ciphersegment_obj, &ciphersegment_view, PyBUF_WRITABLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "ciphersegment must be writable");
+      goto bailout;
+    }
+
+    if (PyObject_GetBuffer(segment_obj, &segment_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "segment buffer must be readable");
+      goto bailout;
+    }
+
+    if (PyObject_GetBuffer(key_obj, &key_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "key buffer must be readable");
+      goto bailout;
+    }
+
+    ciphersegment = (uint8_t *)ciphersegment_view.buf;
+    ciphersegment_len = ciphersegment_view.len;
+    segment = (uint8_t *)segment_view.buf;
+    segment_len = segment_view.len;
+    key = (uint8_t *)key_view.buf;
+    //key_len = key_view.len;
+
+    if (ciphersegment_len < segment_len + CIPHER_DIFF) {
+      PyErr_SetString(PyExc_AssertionError, "Invalid buffer sizes");
+      goto bailout;
+    }
+
+    randombytes_buf(ciphersegment, NONCE_LEN);
+
+    if(crypto_aead_chacha20poly1305_ietf_encrypt(ciphersegment + NONCE_LEN, &clen,
+						 segment, segment_len,
+						 NULL, 0, NULL,
+						 ciphersegment, key) != 0){
+      PyErr_SetString(PyExc_ValueError, "Segment encryption failed");
+      goto bailout;
+    }
+
+    ret = PyLong_FromUnsignedLongLong(clen + NONCE_LEN);
+    /* fallthrough */
+
+bailout:
+    PyBuffer_Release(&ciphersegment_view);
+    PyBuffer_Release(&segment_view);
+    PyBuffer_Release(&key_view);
+    return ret;
+}
+
+static PyObject*
+crypt4gh_chacha20poly1305_decrypt(PyObject* self, PyObject* args)
+{
+    PyObject *ciphersegment_obj, *segment_obj, *key_obj;
+    uint8_t *ciphersegment, *segment, *key;
+    Py_ssize_t ciphersegment_len, segment_len; //, key_len;
+    unsigned long long slen;
+    PyObject* ret;
+    Py_buffer ciphersegment_view, segment_view, key_view;
+
+    memset(&ciphersegment_view, 0, sizeof(ciphersegment_view));
+    memset(&segment_view, 0, sizeof(segment_view));
+    memset(&key_view, 0, sizeof(key_view));
+
+    if (!PyArg_ParseTuple(args, "OOO",
+			  &segment_obj,
+			  &ciphersegment_obj,
+			  &key_obj)) {
+      PyErr_SetString(PyExc_TypeError, "All arguments must be buffer objects");
+      return NULL;
+    }
+
+    ret = NULL;
+
+    if (PyObject_GetBuffer(segment_obj, &segment_view, PyBUF_WRITABLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "segment must be writable");
+      goto bailout;
+    }
+
+    if (PyObject_GetBuffer(ciphersegment_obj, &ciphersegment_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "ciphersegment buffer must be readable");
+      goto bailout;
+    }
+
+    if (PyObject_GetBuffer(key_obj, &key_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "key buffer must be readable");
+      goto bailout;
+    }
+
+    ciphersegment = (uint8_t *)ciphersegment_view.buf;
+    ciphersegment_len = ciphersegment_view.len;
+    segment = (uint8_t *)segment_view.buf;
+    segment_len = segment_view.len;
+    key = (uint8_t *)key_view.buf;
+    //key_len = key_view.len;
+
+    if (segment_len < ciphersegment_len - CIPHER_DIFF) {
+      PyErr_SetString(PyExc_AssertionError, "Invalid buffer sizes");
+      goto bailout;
+    }
+
+    if(crypto_aead_chacha20poly1305_ietf_decrypt(segment, &slen,
+						 NULL,
+						 ciphersegment + NONCE_LEN, ciphersegment_len - NONCE_LEN,
+						 NULL, 0, ciphersegment /* nonce */, key) != 0){
+      PyErr_SetString(PyExc_ValueError, "Ciphersegment decryption failed");
+      goto bailout;
+    }
+
+    ret = PyLong_FromUnsignedLongLong(slen);
+    /* fallthrough */
+
+bailout:
+    PyBuffer_Release(&ciphersegment_view);
+    PyBuffer_Release(&segment_view);
+    PyBuffer_Release(&key_view);
+    return ret;
+}
+
+
+static PyObject*
+crypt4gh_kx_server(PyObject* self, PyObject* args)
+{
+    PyObject *server_public_key_obj, *server_secret_key_obj, *client_public_key_obj;
+    Py_ssize_t server_public_key_len, server_secret_key_len, client_public_key_len;
+    uint8_t *server_public_key, *server_secret_key, *client_public_key;
+    Py_buffer server_public_key_view, server_secret_key_view, client_public_key_view;
+
+    PyObject* ret = NULL;
+    unsigned char shared_key[crypto_kx_SESSIONKEYBYTES];
+    unsigned char ignored[crypto_kx_SESSIONKEYBYTES];
+
+    memset(&server_public_key_view, 0, sizeof(server_public_key_view));
+    memset(&server_secret_key_view, 0, sizeof(server_secret_key_view));
+    memset(&client_public_key_view, 0, sizeof(client_public_key_view));
+    memset(shared_key, 0, crypto_kx_SESSIONKEYBYTES);
+
+    if (!PyArg_ParseTuple(args, "OOO",
+			  &server_public_key_obj,
+			  &server_secret_key_obj,
+			  &client_public_key_obj)) {
+      PyErr_SetString(PyExc_TypeError, "All arguments must be buffer objects");
+      return NULL;
+    }
+
+    if (PyObject_GetBuffer(server_public_key_obj, &server_public_key_view, PyBUF_SIMPLE) != 0 ||
+	PyObject_GetBuffer(server_secret_key_obj, &server_secret_key_view, PyBUF_SIMPLE) != 0 ||
+	PyObject_GetBuffer(client_public_key_obj, &client_public_key_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "buffers must be readable");
+      goto bailout;
+    }
+
+    server_public_key = (uint8_t *)server_public_key_view.buf;
+    server_public_key_len = server_public_key_view.len;
+    server_secret_key = (uint8_t *)server_secret_key_view.buf;
+    server_secret_key_len = server_secret_key_view.len;
+    client_public_key = (uint8_t *)client_public_key_view.buf;
+    client_public_key_len = client_public_key_view.len;
+
+    if (server_public_key_len != crypto_kx_PUBLICKEYBYTES ||
+	server_secret_key_len != crypto_kx_SECRETKEYBYTES ||
+	client_public_key_len != crypto_kx_PUBLICKEYBYTES) {
+      PyErr_SetString(PyExc_AssertionError, "Wrong key sizes");
+      goto bailout;
+    }
+
+    if(crypto_kx_server_session_keys(ignored, shared_key,
+				     server_public_key,
+				     server_secret_key,
+				     client_public_key) != 0){
+      PyErr_SetString(PyExc_ValueError, "Server session key generation failed.");
+    }
+
+    ret = PyBytes_FromStringAndSize((const char*)shared_key, crypto_kx_SESSIONKEYBYTES);
+
+bailout:
+    PyBuffer_Release(&server_public_key_view);
+    PyBuffer_Release(&server_secret_key_view);
+    PyBuffer_Release(&client_public_key_view);
+    return ret;
+}
+
+static PyObject*
+crypt4gh_kx_client(PyObject* self, PyObject* args)
+{
+    PyObject *server_public_key_obj, *client_secret_key_obj, *client_public_key_obj;
+    Py_ssize_t server_public_key_len, client_secret_key_len, client_public_key_len;
+
+    uint8_t *server_public_key, *client_secret_key, *client_public_key;
+    Py_buffer server_public_key_view, client_secret_key_view, client_public_key_view;
+
+    PyObject* ret = NULL;
+    unsigned char shared_key[crypto_kx_SESSIONKEYBYTES];
+    unsigned char ignored[crypto_kx_SESSIONKEYBYTES];
+
+    memset(&client_public_key_view, 0, sizeof(client_public_key_view));
+    memset(&client_secret_key_view, 0, sizeof(client_secret_key_view));
+    memset(&server_public_key_view, 0, sizeof(server_public_key_view));
+    memset(shared_key, 0, crypto_kx_SESSIONKEYBYTES);
+
+    if (!PyArg_ParseTuple(args, "OOO",
+			  &client_public_key_obj,
+			  &client_secret_key_obj,
+			  &server_public_key_obj)) {
+      PyErr_SetString(PyExc_TypeError, "All arguments must be buffer objects");
+      Py_RETURN_NONE;
+    }
+
+    if (PyObject_GetBuffer(client_public_key_obj, &client_public_key_view, PyBUF_SIMPLE) != 0 ||
+	PyObject_GetBuffer(client_secret_key_obj, &client_secret_key_view, PyBUF_SIMPLE) != 0 ||
+	PyObject_GetBuffer(server_public_key_obj, &server_public_key_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "buffers must be readable");
+      goto bailout;
+    }
+
+    client_public_key = (uint8_t *)client_public_key_view.buf;
+    client_public_key_len = client_public_key_view.len;
+    client_secret_key = (uint8_t *)client_secret_key_view.buf;
+    client_secret_key_len = client_secret_key_view.len;
+    server_public_key = (uint8_t *)server_public_key_view.buf;
+    server_public_key_len = server_public_key_view.len;
+
+    if (client_public_key_len != crypto_kx_PUBLICKEYBYTES ||
+	client_secret_key_len != crypto_kx_SECRETKEYBYTES ||
+	server_public_key_len != crypto_kx_PUBLICKEYBYTES) {
+      PyErr_SetString(PyExc_AssertionError, "Wrong key sizes");
+      goto bailout;
+    }
+
+    if(crypto_kx_client_session_keys(shared_key, ignored,
+				     client_public_key,
+				     client_secret_key,
+				     server_public_key) != 0){
+      PyErr_SetString(PyExc_ValueError, "Client session key generation failed.");
+    }
+
+    ret = PyBytes_FromStringAndSize((const char*)shared_key, crypto_kx_SESSIONKEYBYTES);
+
+bailout:
+    PyBuffer_Release(&client_public_key_view);
+    PyBuffer_Release(&client_secret_key_view);
+    PyBuffer_Release(&server_public_key_view);
+    return ret;
+}
+
+static PyObject*
+crypt4gh_derive_pk(PyObject* self, PyObject* args)
+{
+    PyObject *n_obj;
+    Py_buffer n_view;
+
+    PyObject* ret = NULL;
+
+    unsigned char q[crypto_scalarmult_BYTES];
+
+    memset(&n_view, 0, sizeof(n_view));
+    memset(&q, 0, sizeof(q));
+
+    if (!PyArg_ParseTuple(args, "O", &n_obj)) {
+      PyErr_SetString(PyExc_TypeError, "n must be a buffer object");
+      return NULL;
+    }
+
+    if (PyObject_GetBuffer(n_obj, &n_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "n must be readable");
+      goto bailout;
+    }
+
+    if (n_view.len != crypto_scalarmult_SCALARBYTES) {
+      PyErr_SetString(PyExc_AssertionError, "wrong input size");
+      goto bailout;
+    }
+
+    if(crypto_scalarmult_base(q, (unsigned char*)n_view.buf) != 0)
+      PyErr_SetString(PyExc_RuntimeError, "can't derive public key from private key.");
+    else
+      ret = PyBytes_FromStringAndSize((const char*)q, crypto_scalarmult_BYTES);
+
+bailout:
+    PyBuffer_Release(&n_view);
+    return ret;
+}
+
+static PyObject*
+crypt4gh_sign_ed25519_pk_to_curve25519(PyObject* self, PyObject* args)
+{
+    PyObject *ed25519_pk_obj;
+    Py_ssize_t ed25519_pk_len;
+    uint8_t *ed25519_pk;
+    Py_buffer ed25519_pk_view;
+
+    PyObject* ret = NULL;
+    unsigned char x25519_pk[crypto_scalarmult_curve25519_BYTES];
+
+    memset(&ed25519_pk_view, 0, sizeof(ed25519_pk_view));
+    memset(x25519_pk, 0, crypto_scalarmult_curve25519_BYTES);
+
+    if (!PyArg_ParseTuple(args, "O",
+			  &ed25519_pk_obj)) {
+      PyErr_SetString(PyExc_TypeError, "ed25519 public key must be buffer objects");
+      return NULL;
+    }
+
+    if (PyObject_GetBuffer(ed25519_pk_obj, &ed25519_pk_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "ed25519 public key must be readable");
+      goto bailout;
+    }
+
+    ed25519_pk = (uint8_t *)ed25519_pk_view.buf;
+    ed25519_pk_len = ed25519_pk_view.len;
+
+    if (ed25519_pk_len != crypto_sign_ed25519_PUBLICKEYBYTES) {
+      PyErr_SetString(PyExc_ValueError, "Invalid ed25519 public key size");
+      goto bailout;
+    }
+
+    if(crypto_sign_ed25519_pk_to_curve25519(x25519_pk, ed25519_pk) != 0)
+      PyErr_SetString(PyExc_RuntimeError, "Can't convert ed25519 public key to curve25519.");
+    else
+      ret = PyBytes_FromStringAndSize((const char*)x25519_pk, crypto_scalarmult_curve25519_BYTES);
+
+bailout:
+    PyBuffer_Release(&ed25519_pk_view);
+    return ret;
+}
+
+static PyObject*
+crypt4gh_sign_ed25519_sk_to_curve25519(PyObject* self, PyObject* args)
+{
+    PyObject *ed25519_skpk_obj;
+    Py_ssize_t ed25519_skpk_len;
+    uint8_t *ed25519_skpk;
+    Py_buffer ed25519_skpk_view;
+
+    PyObject* ret = NULL;
+    unsigned char x25519_sk[crypto_scalarmult_curve25519_BYTES];
+
+    memset(&ed25519_skpk_view, 0, sizeof(ed25519_skpk_view));
+    memset(x25519_sk, 0, crypto_scalarmult_curve25519_BYTES);
+
+    if (!PyArg_ParseTuple(args, "O",
+			  &ed25519_skpk_obj)) {
+      PyErr_SetString(PyExc_TypeError, "ed25519 secret key must be buffer objects");
+      return NULL;
+    }
+
+    if (PyObject_GetBuffer(ed25519_skpk_obj, &ed25519_skpk_view, PyBUF_SIMPLE) != 0) {
+      PyErr_SetString(PyExc_BufferError, "ed25519 secret key must be readable");
+      goto bailout;
+    }
+
+    ed25519_skpk = (uint8_t *)ed25519_skpk_view.buf;
+    ed25519_skpk_len = ed25519_skpk_view.len;
+
+    if (ed25519_skpk_len != crypto_sign_ed25519_SECRETKEYBYTES) {
+      PyErr_SetString(PyExc_ValueError, "Invalid ed25519 secret key size");
+      goto bailout;
+    }
+
+    if(crypto_sign_ed25519_sk_to_curve25519(x25519_sk, ed25519_skpk) != 0)
+      PyErr_SetString(PyExc_RuntimeError, "Can't convert ed25519 secret key to curve25519.");
+    else
+      ret = PyBytes_FromStringAndSize((const char*)x25519_sk, crypto_scalarmult_curve25519_BYTES);
+
+bailout:
+    PyBuffer_Release(&ed25519_skpk_view);
+    return ret;
+}
+
+// Method definitions
+static PyMethodDef methods[] = {
+    {"chacha20poly1305_encrypt",
+     crypt4gh_chacha20poly1305_encrypt,
+     METH_VARARGS, "Encrypt data using ChaCha20-Poly1305"},
+    {"chacha20poly1305_decrypt",
+     crypt4gh_chacha20poly1305_decrypt,
+     METH_VARARGS, "Decrypt data using ChaCha20-Poly1305"},
+    {"kx_server",
+     crypt4gh_kx_server,
+     METH_VARARGS, "Generate shared key for the server."},
+    {"kx_client",
+     crypt4gh_kx_client,
+     METH_VARARGS, "Generate shared key for the client."},
+    {"derive_pk",
+     crypt4gh_derive_pk,
+     METH_VARARGS, "Generate shared key for the client."},
+    {"sign_ed25519_pk_to_curve25519",
+     crypt4gh_sign_ed25519_pk_to_curve25519,
+     METH_VARARGS, "Converts a public Ed25519 key to a public Curve25519 key."},
+    {"sign_ed25519_sk_to_curve25519",
+     crypt4gh_sign_ed25519_sk_to_curve25519,
+     METH_VARARGS, "Converts a secret Ed25519 key to a secret Curve25519 key."},
+
+    {NULL, NULL, 0, NULL}
+};
+
+
+// Module definition
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    module_name,
+    NULL,
+    -1,
+    methods
+};
+
+// Module initialization
+PyMODINIT_FUNC PyInit_sodium(void) {
+    if (sodium_init() == -1) {
+      return NULL;
+    }
+    return PyModule_Create(&module);
+}

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
+    # rust: "1.70"
+    # golang: "1.20"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -8,9 +8,9 @@ Python Modules
 
 .. autosummary::
 
-    crypt4gh.lib
-    crypt4gh.header
-    crypt4gh.keys
+    lib
+    header
+    keys
 
 ----
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,6 @@
 #
 import os
 import sys
-import datetime
-from unittest.mock import MagicMock
 
 # Get the project root dir, which is the parent dir of this
 #sys.path.insert(0, os.path.dirname(os.getcwd()))
@@ -36,19 +34,18 @@ templates_path = ['templates']
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = {
+    '.rst': 'restructuredtext',
+    #'.txt': 'restructuredtext',
+    #'.md': 'markdown',
+}
 
 # The master toctree document.
-master_doc = 'index'
-
-# Get current year
-current_year = str(datetime.date.today().year)
+#master_doc = 'index'
 
 # General information about the project.
 project = 'Crypt4GH'
-copyright = f'{current_year}, EGA-CRG System Developers'
+copyright = '%Y, EGA-CRG System Developers'
 author = crypt4gh.__author__
 
 # The version info for the project you're documenting, acts as replacement for
@@ -65,12 +62,15 @@ release = str(crypt4gh.__version__)
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build',
+                    'Thumbs.db',
+                    '.DS_Store',
+                    '__docs__']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -83,7 +83,7 @@ autosummary_generate = True
 
 # -- Options for HTML output ----------------------------------------------
 
-html_title = 'GA4GH cryptor'
+html_title = 'GA4GH crypt4gh'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -98,11 +98,35 @@ html_title = 'GA4GH cryptor'
 # }
 
 html_theme = 'sphinx_rtd_theme'
+
+html_css_files = [
+    'custom.css',
+    #'https://example.com/css/custom.css',
+    #('print.css', {'media': 'print'}),
+]
+
+smartquotes = True
+
+# html_theme_options = {
+#     'collapse_navigation': True,
+#     'sticky_navigation': True,
+#     'prev_next_buttons_location': 'bottom',
+# }
+
 html_theme_options = {
+    'logo_only': False,
+    # 'style_external_links': False,
+    # 'vcs_pageview_mode': '',
+    # 'style_nav_header_background': 'white',
+    # 'flyout_display': 'hidden',
+    'version_selector': True,
+    'language_selector': False,
+    # Toc options
     'collapse_navigation': True,
     'sticky_navigation': True,
     #'navigation_depth': 4,
-    'display_version': True,
+    #'includehidden': True,
+    'titles_only': False,
     'prev_next_buttons_location': 'bottom',
 }
 
@@ -126,15 +150,8 @@ html_sidebars = {
     ]
 }
 
-
 today_fmt = '%B %d, %Y'
 
-def setup(app):
-    app.add_css_file('custom.css')
 
 # -- Other stuff ----------------------------------------------------------
 htmlhelp_basename = 'crypt4gh'
-latex_elements = {}
-latex_documents = [ (master_doc, 'crypt4gh.tex', 'GA4GH cryptor', 'EGA-CRG System Developers', 'manual') ]
-man_pages = [ (master_doc, 'crypt4gh', 'GA4GH cryptor', [author], 1) ]
-texinfo_documents = [ (master_doc, 'crypt4gh', 'GA4GH cryptor', author, 'GA4GH cryptor', 'GA4GH cryptographic tools', 'Miscellaneous') ]

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,60 @@
+Examples
+========
+
+Assume Alice, with public/private key alice.pub and alice.sec respectively, wants to send a message to Bob, with public/private key bob.pub and bob.sec respectively.
+
+Alice can encrypt the message M with:
+
+.. code-block:: console
+
+    $ crypt4gh encrypt --sk alice.sec --recipient_pk bob.pub < M > M.c4gh
+
+Bob can decrypt the encrypted message with:
+
+.. code-block:: console
+
+    $ crypt4gh decrypt --sk bob.sec < M.c4gh > M
+
+If Bob wants to, optionally, verify that the message indeed comes from Alice, he needs to fetch Alice's public key via another trusted channel. He can then decrypt *and* check the provenance of the file with:
+
+.. code-block:: console
+
+    $ crypt4gh decrypt --sk bob.sec --sender_pk alice.pub < M.c4gh > M
+
+Any user can generate a keypair with:
+
+.. code-block:: console
+
+    $ crypt4gh-keygen --sk user.sec --pk user.pub
+
+The private key will be encrypted with a passphrase. The user is prompted at the terminal for that passphrase.
+
+Storing the encrypted header separately
+---------------------------------------
+
+The encrypted header can be stored separately from the encrypted payload. Splitting header from payload is useful when payloads are stored in a shared location, for example. In this case, only the header needs to be re-encrypted (for a specific recipient) while the encrypted payload remains untouched.
+
+To store the encrypted header in a separate file ``header.bob.c4gh``, use the flag ``--header``. Alice sends a message to Bob (and herself), sharing the message payload.
+
+.. code-block:: console
+
+    $ crypt4gh encrypt --sk alice.sec --recipient_pk bob.pub --recipient_pk alice.pub --header header.bob.c4gh < M > M.payload.c4gh
+
+Bob can then decrypt the message by concatenating the header and the payload, and decrypting the whole file:
+
+.. code-block:: console
+
+    $ cat header.bob.c4gh M.payload.c4gh | crypt4gh decrypt --sk bob.sec > M
+
+To re-encrypt the message for another user Eve, with public key ``eve.pub``, Alice can run the ``crypt4gh reencrypt`` command: 
+
+.. code-block:: console
+
+    $ crypt4gh reencrypt --sk alice.sec --recipient_pk eve.pub < header.bob.c4gh > header.eve.c4gh
+    # Alice can decrypt header.bob.c4gh, she is a recipient
+
+Eve can now also read the same payload with:
+
+.. code-block:: console
+
+    $ cat header.eve.c4gh M.payload.c4gh | crypt4gh decrypt --sk eve.sec > M

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,26 +41,26 @@ Alice decrypts the encrypted file:
    :alt: Demo
 
 
-Table of Contents
-=================
-
 .. toctree::
    :maxdepth: 1
    :name: toc
+   :hidden:
 
    Installation         <setup>
    Encryption           <encryption>
    Key Format           <keys>
    Usage & Examples     <usage>
+   Examples             <examples>
    Python Modules       <code>
 
 
-|Travis| | Version |version| | Generated |today|
+|build| |version|, generated |today|
 
 
-.. |Travis| image:: https://travis-ci.org/EGA-archive/crypt4gh.svg?branch=master
+.. |build| image:: https://github.com/EGA-archive/crypt4gh/workflows/Testsuite/badge.svg
 	:alt: Build Status
 	:class: inline-baseline
+	:target: https://github.com/EGA-archive/crypt4gh/actions	
 
 .. |moreabout| unicode:: U+261E .. right pointing finger
 .. |connect| unicode:: U+21cc .. <-_>

--- a/docs/keys.rst
+++ b/docs/keys.rst
@@ -1,6 +1,8 @@
-.. note:: This utility supports OpenSSH key-format (version 6.5 or above)
-	  if the key was generated with type ``ed25519`` (ie with ``ssh-keygen -t ed25519 ...``).
-	  Otherwise, this utility can generate keys in the following format...
+.. note::
+
+   This utility supports OpenSSH key-format (version 6.5 or above) if the key was generated with type ``ed25519`` (ie with ``ssh-keygen -t ed25519 ...``).
+
+   Otherwise, this utility can generate keys in the following format...
 
 
 Crypt4GH Key Format

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -56,8 +56,8 @@ For that, you set the following environment variables before running ``pip insta
 
 ----
 
-Tests
-=====
+Testsuite
+=========
 
 You can run a few tests after installation.
 We provide a testsuite simulating, for example, that Bob encrypts a randomly-generated file for Alice and Alice decrypts it.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -13,9 +13,13 @@ or compile/install it from sources:
 
 .. code-block:: console
 
-    git clone --recursive https://github.com/EGA-archive/crypt4gh
-    pip install -r crypt4gh/requirements.txt
-    pip install ./crypt4gh
+   git clone --recursive https://github.com/EGA-archive/crypt4gh
+   pip install -r crypt4gh/requirements.txt
+   pip install ./crypt4gh
+   #
+   # or just
+   #
+   pip install git+https://github.com/EGA-archive/crypt4gh.git
 
 
 The above will use a version of `libsodium`_ bundled in the repository as a submodule (hence cloning with ``--recursive``).

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -9,47 +9,88 @@ The sources for EGA cryptor can be downloaded and installed from the `EGA-archiv
 
     pip install crypt4gh
 
-or using:
+or compile/install it from sources:
 
 .. code-block:: console
 
-    git clone https://github.com/EGA-archive/crypt4gh
+    git clone --recursive https://github.com/EGA-archive/crypt4gh
     pip install -r crypt4gh/requirements.txt
     pip install ./crypt4gh
-    #
-    # or just
-    #
-    pip install git+https://github.com/EGA-archive/crypt4gh.git
+
+
+The above will use a version of `libsodium`_ bundled in the repository as a submodule (hence cloning with ``--recursive``).
+You have the possibility to use the version of libsodium already installed on your system.
+For that, you set the following environment variables before running ``pip install``.
+
+.. code-block:: console
+
+    export SODIUM_INSTALL=system
+
+    # If libsodium is not installed in default locations,
+    # you need to adjust CFLAGS and LDFLAGS:
+    export CFLAGS="-I/path/to/libsodium/include"
+    export LDFLAGS="-L/path/to/libsodium/lib -lsodium"
+    
+    # For example, using pkg-config
+    export CFLAGS="$(pkg-config --cflags libsodium)"
+    export LDFLAGS="$(pkg-config --libs libsodium)"                    # on macos
+    export LDFLAGS="-Wl,--no-as-needed $(pkg-config --libs libsodium)" # on linux
+
+    # and finally:
+    pip install ./crypt4gh
+
+
+.. note::
+
+   The compiler on macOS is more agressive and restricts the compilation to only the functions it uses from libsodium. This creates a smaller **crypt4gh** module.
+
+   On Linux, it is more conservative and keeps *all* libsodium functions, and therefore produces a bigger module. It seems that you also need to pass ``-Wl,--no-as-needed``, on Linux, to the linker (ie add it in LDFLAGS) to resolve symbols in the python module.
+
+   Help me out if you know how to resolve that.
 
 
 
 .. _EGA-archive Github repo: https://github.com/EGA-archive/crypt4gh
+.. _libsodium: https://libsodium.org
 
 
 ----
 
-You can run a few tests after you installed the python package (and its dependencies).
+Tests
+=====
+
+You can run a few tests after installation.
 We provide a testsuite simulating, for example, that Bob encrypts a randomly-generated file for Alice and Alice decrypts it.
-We use `BATS <https://github.com/bats-core/bats-core>`_ to run the testsuite (so... first install it).
+We use `BATS <https://github.com/bats-core/bats-core>`_ to run the testsuite (so... install bats first).
 
 .. code-block:: console
 
-    git clone https://github.com/EGA-archive/crypt4gh
-    pip install -r crypt4gh/requirements.txt
-    bats crypt4gh/tests
+    cd [path/to/crypt4gh/cloned/repository]
+    bats tests
 
 which should output, something along those lines (yes, the testsuite might grow):
 
 .. code-block:: console
 
+   ✓ Bob sends a secret message to Alice, buried in some random data
+
    ✓ Bob sends a secret (random) 10MB file to Alice
    ✓ Bob sends the testfile secretly to Alice
    ✓ Bob encrypts the testfile for himself and reencrypts it for Alice
+   ✓ Bob sends a secret (random) 10MB file to Alice, without his key
+
+   ✓ Bob sends the testfile secretly (with separate header and data) to Alice
+   ✓ Bob encrypts the testfile for himself (with separate header) and reencrypts the header for Alice
+
+   ✓ Bob sends a secret (random) 10MB file to Alice, using his ssh-key
+   ✓ Bob sends a secret (random) 10MB file to Alice, using Alice's ssh-key
+   ✓ Bob sends a secret (random) 10MB file to Alice, both using their ssh-keys
+
+   ✓ Bob sends the testfile secretly to himself and Alice
+   ✓ Bob encrypts the testfile for himself and reencrypts it for himself and Alice
+
    ✓ Bob sends only the Bs from the testfile secretly to Alice
    ✓ Bob sends one A, all Bs, one C, from the testfile secretly to Alice
    ✓ Bob rearranges the encrypted testfile to send one A, all Bs, one C, to Alice
-   ✓ Bob sends only the Bs from the testfile secretly to Alice
-   ✓ Bob sends one A, all Bs, one C, from the testfile secretly to Alice
-   ✓ Bob rearranges the encrypted testfile to send one A, all Bs, one C, to Alice
-   
-   10 tests, 0 failures
+
+   15 tests, 0 failures

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,29 +9,35 @@ The usual ``-h`` flag shows you the different options that the tool accepts.
 
     $ crypt4gh -h
 
-    Utility for the cryptographic GA4GH standard, reading from stdin and outputting to stdout.
+   Utility for the cryptographic GA4GH standard, reading from stdin and outputting to stdout.
 
-    Usage:
-	crypt4gh [-hv] [--log <file>] encrypt [--sk <path>] --recipient_pk <path> [--recipient_pk <path>]... [--range <start-end>]
-	crypt4gh [-hv] [--log <file>] decrypt [--sk <path>] [--sender_pk <path>] [--range <start-end>]
-	crypt4gh [-hv] [--log <file>] rearrange [--sk <path>] --range <start-end>
-	crypt4gh [-hv] [--log <file>] reencrypt [--sk <path>] --recipient_pk <path> [--recipient_pk <path>]... [--trim]
+   Usage:
+	crypt4gh [-hv] [--log <file>] encrypt [--sk <path>] --recipient_pk <path> [--recipient_pk <path>]... [--range <start-end>] [--header <path>]
+        crypt4gh [-hv] [--log <file>] decrypt [--sk <path>] [--sender_pk <path>] [--range <start-end>]
+        crypt4gh [-hv] [--log <file>] rearrange [--sk <path>] --range <start-end>
+        crypt4gh [-hv] [--log <file>] reencrypt [--sk <path>] --recipient_pk <path> [--recipient_pk <path>]... [--trim] [--header-only]
 
-    Options:
-	-h, --help             Prints this help and exit
-	-v, --version          Prints the version and exits
-	--log <file>           Path to the logger file (in YML format)
-	--sk <keyfile>         Curve25519-based Private key
-	                       When encrypting, if neither the private key nor C4GH_SECRET_KEY are specified, we generate a new key 
-	--recipient_pk <path>  Recipient's Curve25519-based Public key
-	--sender_pk <path>     Peer's Curve25519-based Public key to verify provenance (aka, signature)
-	--range <start-end>    Byte-range either as  <start-end> or just <start> (Start included, End excluded)
-	-t, --trim             Keep only header packets that you can decrypt
+   Options:
+        -h, --help             Prints this help and exit
+        -v, --version          Prints the version and exits
+        --log <file>           Path to the logger file (in YML format)
+        --sk <keyfile>         Curve25519-based Private key
+                               When encrypting, if neither the private key nor C4GH_SECRET_KEY are specified, we generate a new key 
+        --recipient_pk <path>  Recipient's Curve25519-based Public key
+        --sender_pk <path>     Peer's Curve25519-based Public key to verify provenance (akin to signature)
+        --range <start-end>    Byte-range either as  <start-end> or just <start> (Start included, End excluded)
+        -t, --trim             Keep only header packets that you can decrypt
+        --header <path>        Where to write the header (default: stdout)
+        --header-only          Whether the input data consists only of a header (default: false)
 
-
-    Environment variables:
-	C4GH_LOG         If defined, it will be used as the default logger
-	C4GH_SECRET_KEY  If defined, it will be used as the default secret key (ie --sk ${C4GH_SECRET_KEY})
+   Environment variables:
+        C4GH_LOG         If defined, it will be used as the default logger
+        C4GH_SECRET_KEY  If defined, it will be used as the default secret key (ie --sk ${{C4GH_SECRET_KEY}})
+        C4GH_PASSPHRASE  If defined, it will be used as the passphrase
+                         for decoding the secret key, replacing the callback.
+                         Note: this is insecure.
+        C4GH_DEBUG       If True, it will print (a lot of) debug information.
+                         Note: the output might contain secrets
 
 
 Examples
@@ -68,22 +74,29 @@ The private key will be encrypted with a passphrase. The user is prompted at the
 Storing the encrypted header separately
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The encrypted header can be stored separately from the encrypted data. This is useful, for example, when sharing the encrypted message with many recipients. In this case, only the header needs to be re-encrypted (for a specific recipient) while the encrypted data can stay the same.
+The encrypted header can be stored separately from the encrypted payload. Splitting header from payload is useful when payloads are stored in a shared location, for example. In this case, only the header needs to be re-encrypted (for a specific recipient) while the encrypted payloads remains untouched.
 
-To store the encrypted header in a separate file ``header.dat``, use the flag ``--header``:
-
-.. code-block:: console
-
-    $ crypt4gh encrypt --sk alice.sec --recipient_pk bob.pub --header header.bob.c4gh < M > M.data.c4gh
-
-Bob can then decrypt the message by concatenating the header and the data, and decrypting the whole file:
+To store the encrypted header in a separate file ``header.bob.c4gh``, use the flag ``--header``. Alice sends a message to Bob, sharing the message payload (and herself).
 
 .. code-block:: console
 
-    $ cat header.bob.c4gh M.data.c4gh | crypt4gh decrypt --sk bob.sec > M
+    $ crypt4gh encrypt --sk alice.sec --recipient_pk bob.pub --recipient_pk alice.pub --header header.bob.c4gh < M > M.payload.c4gh
+
+Bob can then decrypt the message by concatenating the header and the payload, and decrypting the whole file:
+
+.. code-block:: console
+
+    $ cat header.bob.c4gh M.payload.c4gh | crypt4gh decrypt --sk bob.sec > M
 
 To re-encrypt the message for another user Eve, with public key ``eve.pub``, Alice can run the ``crypt4gh reencrypt`` command: 
 
 .. code-block:: console
 
-    $ crypt4gh reencrypt --sk alice.sec --recipient_pk eve.pub < header.alice.c4gh > header.eve.c4gh
+    $ crypt4gh reencrypt --sk alice.sec --recipient_pk eve.pub < header.bob.c4gh > header.eve.c4gh
+    # Alice can decrypt header.bob.c4gh, she is a recipient
+
+Eve can now also read the same payload with:
+
+.. code-block:: console
+
+    $ cat header.eve.c4gh M.payload.c4gh | crypt4gh decrypt --sk eve.sec > M

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,5 +1,5 @@
-Usage & Examples
-================
+Usage
+=====
 
 .. highlight:: shell
 
@@ -38,65 +38,3 @@ The usual ``-h`` flag shows you the different options that the tool accepts.
                          Note: this is insecure.
         C4GH_DEBUG       If True, it will print (a lot of) debug information.
                          Note: the output might contain secrets
-
-
-Examples
---------
-
-Assume Alice, with public/private key alice.pub and alice.sec respectively, wants to send a message to Bob, with public/private key bob.pub and bob.sec respectively.
-
-Alice can encrypt the message M with:
-
-.. code-block:: console
-
-    $ crypt4gh encrypt --sk alice.sec --recipient_pk bob.pub < M > M.c4gh
-
-Bob can decrypt the encrypted message with:
-
-.. code-block:: console
-
-    $ crypt4gh decrypt --sk bob.sec < M.c4gh > M
-
-If Bob wants to, optionally, verify that the message indeed comes from Alice, he needs to fetch Alice's public key via another trusted channel. He can then decrypt *and* check the provenance of the file with:
-
-.. code-block:: console
-
-    $ crypt4gh decrypt --sk bob.sec --sender_pk alice.pub < M.c4gh > M
-
-Any user can generate a keypair with:
-
-.. code-block:: console
-
-    $ crypt4gh-keygen --sk user.sec --pk user.pub
-
-The private key will be encrypted with a passphrase. The user is prompted at the terminal for that passphrase.
-
-Storing the encrypted header separately
----------------------------------------
-
-The encrypted header can be stored separately from the encrypted payload. Splitting header from payload is useful when payloads are stored in a shared location, for example. In this case, only the header needs to be re-encrypted (for a specific recipient) while the encrypted payload remains untouched.
-
-To store the encrypted header in a separate file ``header.bob.c4gh``, use the flag ``--header``. Alice sends a message to Bob (and herself), sharing the message payload.
-
-.. code-block:: console
-
-    $ crypt4gh encrypt --sk alice.sec --recipient_pk bob.pub --recipient_pk alice.pub --header header.bob.c4gh < M > M.payload.c4gh
-
-Bob can then decrypt the message by concatenating the header and the payload, and decrypting the whole file:
-
-.. code-block:: console
-
-    $ cat header.bob.c4gh M.payload.c4gh | crypt4gh decrypt --sk bob.sec > M
-
-To re-encrypt the message for another user Eve, with public key ``eve.pub``, Alice can run the ``crypt4gh reencrypt`` command: 
-
-.. code-block:: console
-
-    $ crypt4gh reencrypt --sk alice.sec --recipient_pk eve.pub < header.bob.c4gh > header.eve.c4gh
-    # Alice can decrypt header.bob.c4gh, she is a recipient
-
-Eve can now also read the same payload with:
-
-.. code-block:: console
-
-    $ cat header.eve.c4gh M.payload.c4gh | crypt4gh decrypt --sk eve.sec > M

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -72,11 +72,11 @@ Any user can generate a keypair with:
 The private key will be encrypted with a passphrase. The user is prompted at the terminal for that passphrase.
 
 Storing the encrypted header separately
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------------------
 
-The encrypted header can be stored separately from the encrypted payload. Splitting header from payload is useful when payloads are stored in a shared location, for example. In this case, only the header needs to be re-encrypted (for a specific recipient) while the encrypted payloads remains untouched.
+The encrypted header can be stored separately from the encrypted payload. Splitting header from payload is useful when payloads are stored in a shared location, for example. In this case, only the header needs to be re-encrypted (for a specific recipient) while the encrypted payload remains untouched.
 
-To store the encrypted header in a separate file ``header.bob.c4gh``, use the flag ``--header``. Alice sends a message to Bob, sharing the message payload (and herself).
+To store the encrypted header in a separate file ``header.bob.c4gh``, use the flag ``--header``. Alice sends a message to Bob (and herself), sharing the message payload.
 
 .. code-block:: console
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,0 @@
-formats:
-    - none
-build:
-    image: latest
-python:
-   version: 3.6
-   setup_py_install: False
-   extra_requirements:
-        - docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pyYaml
 docopt-ng
 cryptography
 bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 docopt-ng
 cryptography
 bcrypt
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyYaml
 docopt-ng
 cryptography
-pynacl
 bcrypt

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ class CleanLibsodium(clean):
 
         if (LIBSODIUM / 'Makefile').exists():
             print('Cleaning up', LIBSODIUM)
-            subprocess.check_call(['make', 'distclean'], cwd=str(LIBSODIUM))
+            subprocess.check_call(['make', 'clean'], cwd=str(LIBSODIUM))
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,25 @@
 import sys
 assert sys.version_info >= (3, 6), "crypt4gh requires python 3.6 or higher"
-
+import subprocess
 from pathlib import Path
-from setuptools import setup, find_packages
+
+from setuptools import setup, find_packages, Extension
 
 _readme = (Path(__file__).parent / "README.md").read_text()
 
+def pkg_config(*args):
+    try:
+        cmd = 'pkg-config ' + ' '.join(args)
+        output = subprocess.check_output(cmd,
+                                         shell=True,
+                                         stderr=subprocess.STDOUT)
+        return output.decode().strip().split()
+    except subprocess.CalledProcessError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
 setup(name='crypt4gh',
-      version='1.7',
+      version='1.8',
       url='https://www.github.com/EGA-archive/crypt4gh',
       license='Apache License 2.0',
       author='Frédéric Haziza',
@@ -28,7 +40,6 @@ setup(name='crypt4gh',
       platforms='any',
       classifiers=[  # Optional
           'Development Status :: 5 - Production/Stable',
-          'License :: OSI Approved :: Apache Software License',
 
           'Natural Language :: English',
           'Operating System :: MacOS :: MacOS X',
@@ -43,10 +54,6 @@ setup(name='crypt4gh',
           'Topic :: Security :: Cryptography',
           'Topic :: Scientific/Engineering :: Bio-Informatics',
 
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-
           'Programming Language :: Python :: Implementation :: CPython',
       ],
       python_requires='>=3.6',
@@ -55,7 +62,14 @@ setup(name='crypt4gh',
           'pyYaml>=5.1.2',
           'docopt-ng', # include version when needed
           'cryptography>=2.8',
-          'pynacl>=1.3.0',
           'bcrypt', # include version when needed
+      ],
+      ext_modules=[
+          Extension('crypt4gh.sodium',
+                    sources=['crypt4gh/sodium.c'],
+                    description='Python C extension for libsodium used by Crypt4GH',
+                    extra_compile_args=pkg_config("--cflags", "libsodium"),
+                    extra_link_args=pkg_config("--libs", "libsodium"),
+                    )
       ],
 )

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,7 @@ libraries=[]
 extra_compile_args = []
 extra_link_args = []
 
-if use_system_sodium:
-    print("Using system-installed libsodium (CFLAGS and LDFLAGS may be needed).")
-else:
-    print("Bundling libsodium from libsodium-stable.")
-    
+if not use_system_sodium:
     # Path to libsodium
     LIBSODIUM = _here / 'libsodium-stable'
     # Path to the built libsodium library
@@ -32,7 +28,7 @@ else:
 
     include_dirs=[str(LIBSODIUM_BUILD / 'include')]
     library_dirs=[str(LIBSODIUM_BUILD / 'lib')]
-    #libraries=['sodium']
+    libraries=['sodium']
     if sys.platform == "darwin":
         extra_compile_args = ['-fPIC','-dead_strip']
         extra_link_args = ['-fPIC','-dead_strip', '-Xlinker', '-dead_strip_dylibs']
@@ -47,9 +43,13 @@ class BuildLibsodium(build_ext):
     def run(self):
 
         if use_system_sodium:
-            print("Skipping libsodium build (using system version).")
+            print('''\
+Skipping build, using system-installed libsodium.
+CFLAGS and LDFLAGS may be needed.
+''')
             return super().run()
 
+        print("Bundling libsodium from libsodium-stable.")
         # Configure and build libsodium
         cmd = ['./configure',
                '--prefix', str(LIBSODIUM_BUILD),

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,70 @@
 import sys
-assert sys.version_info >= (3, 6), "crypt4gh requires python 3.6 or higher"
+import os
+assert sys.version_info >= (3, 9), "crypt4gh requires python 3.9 or higher"
 import subprocess
 from pathlib import Path
+import shutil
 
 from setuptools import setup, find_packages, Extension
+from setuptools.command.build_ext import build_ext
+from distutils.command.clean import clean
 
-_readme = (Path(__file__).parent / "README.md").read_text()
+_here = Path(__file__).parent
 
-def pkg_config(*args):
-    try:
-        cmd = 'pkg-config ' + ' '.join(args)
-        output = subprocess.check_output(cmd,
-                                         shell=True,
-                                         stderr=subprocess.STDOUT)
-        return output.decode().strip().split()
-    except subprocess.CalledProcessError as e:
-        print(str(e), file=sys.stderr)
-        sys.exit(1)
+# Check for SODIUM_INSTALL environment variable
+use_system_sodium = os.environ.get('SODIUM_INSTALL') == 'system'
+
+include_dirs=[]
+library_dirs=[]
+libraries=[]
+
+if use_system_sodium:
+    print("Using system-installed libsodium (CFLAGS and LDFLAGS may be needed).")
+else:
+    print("Bundling libsodium from libsodium-stable.")
+    
+    # Path to libsodium
+    LIBSODIUM = str(_here / 'libsodium-stable')
+    # Path to the built libsodium library
+    LIBSODIUM_BUILD = _here / 'libsodium-build'
+
+    include_dirs=[str(LIBSODIUM_BUILD / 'include')]
+    library_dirs=[str(LIBSODIUM_BUILD / 'lib')]
+    libraries=['sodium']
+
+class BuildLibsodium(build_ext):
+    def run(self):
+
+        if use_system_sodium:
+            print("Skipping libsodium build (using system version).")
+            return super().run()
+
+        # Configure and build libsodium
+        cmd = ['./configure',
+               '--prefix', str(LIBSODIUM_BUILD),
+               '--enable-minimal',
+               '--enable-opt', # since we install it on the machine
+               '--disable-shared',
+               '--enable-static',
+               ]
+        subprocess.check_call(cmd, cwd=LIBSODIUM)
+        subprocess.check_call(['make'], cwd=LIBSODIUM)
+        #subprocess.check_call(['make', 'check'], cwd=LIBSODIUM)
+
+        # copy to LIBSODIUM_BUILD/{include,lib}
+        # so it's easier in the Extension block
+        subprocess.check_call(['make', 'install'], cwd=LIBSODIUM)
+
+        super().run()
+
+class CleanLibsodium(clean):
+    description = 'remove libsodium-build and crypt4gh/libs directories'
+    def run(self):
+        super().run()
+
+        print(f"Removing {LIBSODIUM_BUILD}")
+        shutil.rmtree(LIBSODIUM_BUILD, ignore_errors=True)
+
 
 setup(name='crypt4gh',
       version='1.8',
@@ -25,11 +73,17 @@ setup(name='crypt4gh',
       author='Frédéric Haziza',
       author_email='frederic.haziza@crg.eu',
       description='GA4GH cryptographic utilities',
-      long_description=_readme,
-      long_description_content_type="text/markdown",
+      long_description=(_here / 'README.md').read_text(),
+      long_description_content_type='text/markdown',
       packages=find_packages(),
       include_package_data=True,
-      package_data={ 'crypt4gh': ['completions'] },
+      package_data={
+          'crypt4gh': ['completions',
+                       'libs/*.dylib',
+                       'libs/*.so',
+                       'libs/*.dll',
+                       ],
+      },
       zip_safe=False,
       entry_points={
           'console_scripts': [
@@ -56,20 +110,25 @@ setup(name='crypt4gh',
 
           'Programming Language :: Python :: Implementation :: CPython',
       ],
-      python_requires='>=3.6',
+      python_requires='>=3.9',
       # See https://packaging.python.org/discussions/install-requires-vs-requirements/
       install_requires=[
-          'pyYaml>=5.1.2',
           'docopt-ng', # include version when needed
           'cryptography>=2.8',
           'bcrypt', # include version when needed
+          'setuptools', # include version when needed
       ],
+      cmdclass={
+          'build_ext': BuildLibsodium,
+          'clean': CleanLibsodium,
+      },
       ext_modules=[
-          Extension('crypt4gh.sodium',
-                    sources=['crypt4gh/sodium.c'],
-                    description='Python C extension for libsodium used by Crypt4GH',
-                    extra_compile_args=pkg_config("--cflags", "libsodium"),
-                    extra_link_args=pkg_config("--libs", "libsodium"),
-                    )
+          Extension(
+              'crypt4gh.sodium',
+              sources=['crypt4gh/sodium.c'],
+              include_dirs=include_dirs,
+              library_dirs=library_dirs,
+              libraries=libraries,
+          )
       ],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ use_system_sodium = os.environ.get('SODIUM_INSTALL') == 'system'
 include_dirs=[]
 library_dirs=[]
 libraries=[]
+extra_compile_args = []
+extra_link_args = []
 
 if use_system_sodium:
     print("Using system-installed libsodium (CFLAGS and LDFLAGS may be needed).")
@@ -24,13 +26,22 @@ else:
     print("Bundling libsodium from libsodium-stable.")
     
     # Path to libsodium
-    LIBSODIUM = str(_here / 'libsodium-stable')
+    LIBSODIUM = _here / 'libsodium-stable'
     # Path to the built libsodium library
     LIBSODIUM_BUILD = _here / 'libsodium-build'
 
     include_dirs=[str(LIBSODIUM_BUILD / 'include')]
     library_dirs=[str(LIBSODIUM_BUILD / 'lib')]
-    libraries=['sodium']
+    #libraries=['sodium']
+    if sys.platform == "darwin":
+        extra_compile_args = ['-fPIC','-dead_strip']
+        extra_link_args = ['-fPIC','-dead_strip', '-Xlinker', '-dead_strip_dylibs']
+    else:
+        extra_compile_args = ['-fPIC', '-ffunction-sections', '-fdata-sections']
+        extra_link_args = ['-fPIC', '-Wl,--as-needed', '-Wl,--gc-sections']
+        # on linux, gc-sections is too conservative and keeps more than needed 
+        # the final C-extension will likely be bigger than needed: ¯\_(ツ)_/¯
+        # On macos, the linker is more aggressive and makes a smaller shared object
 
 class BuildLibsodium(build_ext):
     def run(self):
@@ -39,6 +50,12 @@ class BuildLibsodium(build_ext):
             print("Skipping libsodium build (using system version).")
             return super().run()
 
+        # Force GCC on all platforms
+        if sys.platform == "win32":
+            self.compiler = "mingw32"  # or "gcc" if MinGW is set up
+        else:
+            self.compiler = "gcc"  # or "clang" on macOS
+
         # Configure and build libsodium
         cmd = ['./configure',
                '--prefix', str(LIBSODIUM_BUILD),
@@ -46,10 +63,12 @@ class BuildLibsodium(build_ext):
                '--enable-opt', # since we install it on the machine
                '--disable-shared',
                '--enable-static',
+               '--enable-pic',
                ]
-        subprocess.check_call(cmd, cwd=LIBSODIUM)
+        if not (LIBSODIUM / 'config.status').exists():
+            subprocess.check_call(cmd, cwd=LIBSODIUM)
         subprocess.check_call(['make'], cwd=LIBSODIUM)
-        #subprocess.check_call(['make', 'check'], cwd=LIBSODIUM)
+        #subprocess.check_call(['make', 'check'], cwd=str(LIBSODIUM))
 
         # copy to LIBSODIUM_BUILD/{include,lib}
         # so it's easier in the Extension block
@@ -62,8 +81,13 @@ class CleanLibsodium(clean):
     def run(self):
         super().run()
 
-        print(f"Removing {LIBSODIUM_BUILD}")
+        print('Removing', LIBSODIUM_BUILD)
         shutil.rmtree(LIBSODIUM_BUILD, ignore_errors=True)
+
+        if (LIBSODIUM / 'Makefile').exists():
+            print('Cleaning up', LIBSODIUM)
+            subprocess.check_call(['make', 'distclean'], cwd=str(LIBSODIUM))
+
 
 
 setup(name='crypt4gh',
@@ -78,11 +102,7 @@ setup(name='crypt4gh',
       packages=find_packages(),
       include_package_data=True,
       package_data={
-          'crypt4gh': ['completions',
-                       'libs/*.dylib',
-                       'libs/*.so',
-                       'libs/*.dll',
-                       ],
+          'crypt4gh': ['completions'],
       },
       zip_safe=False,
       entry_points={
@@ -125,10 +145,12 @@ setup(name='crypt4gh',
       ext_modules=[
           Extension(
               'crypt4gh.sodium',
-              sources=['crypt4gh/sodium.c'],
-              include_dirs=include_dirs,
-              library_dirs=library_dirs,
-              libraries=libraries,
+              sources = ['crypt4gh/sodium.c'],
+              include_dirs = include_dirs,
+              library_dirs = library_dirs,
+              libraries = libraries,
+              extra_compile_args=extra_compile_args,
+              extra_link_args = extra_link_args
           )
       ],
 )

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,6 @@ class BuildLibsodium(build_ext):
             print("Skipping libsodium build (using system version).")
             return super().run()
 
-        # Force GCC on all platforms
-        if sys.platform == "win32":
-            self.compiler = "mingw32"  # or "gcc" if MinGW is set up
-        else:
-            self.compiler = "gcc"  # or "clang" on macOS
-
         # Configure and build libsodium
         cmd = ['./configure',
                '--prefix', str(LIBSODIUM_BUILD),

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ class CleanLibsodium(clean):
     def run(self):
         super().run()
 
+        if use_system_sodium:
+            return
+
         print('Removing', LIBSODIUM_BUILD)
         shutil.rmtree(LIBSODIUM_BUILD, ignore_errors=True)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import sys
+assert sys.version_info >= (3, 6), "crypt4gh requires python 3.6 or higher"
+
 import os
-assert sys.version_info >= (3, 9), "crypt4gh requires python 3.9 or higher"
 import subprocess
 from pathlib import Path
 import shutil
@@ -92,7 +93,7 @@ setup(name='crypt4gh',
       url='https://www.github.com/EGA-archive/crypt4gh',
       license='Apache License 2.0',
       author='Frédéric Haziza',
-      author_email='frederic.haziza@crg.eu',
+      author_email='silverdaz@gmail.com',
       description='GA4GH cryptographic utilities',
       long_description=(_here / 'README.md').read_text(),
       long_description_content_type='text/markdown',
@@ -127,7 +128,7 @@ setup(name='crypt4gh',
 
           'Programming Language :: Python :: Implementation :: CPython',
       ],
-      python_requires='>=3.9',
+      python_requires='>=3.6',
       # See https://packaging.python.org/discussions/install-requires-vs-requirements/
       install_requires=[
           'docopt-ng', # include version when needed

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import sys
-assert sys.version_info >= (3, 6), "crypt4gh requires python 3.6 or higher"
+assert sys.version_info >= (3, 6), "setup.py requires python 3.6 or higher"
 
 import os
 import subprocess

--- a/tests/_common/edit_list_gen.py
+++ b/tests/_common/edit_list_gen.py
@@ -14,6 +14,7 @@ from getpass import getpass
 
 from crypt4gh.keys import get_private_key, get_public_key
 from crypt4gh import header, lib, SEGMENT_SIZE
+from crypt4gh.lib import sodium
 
 if __name__ == '__main__':
 
@@ -88,18 +89,16 @@ if __name__ == '__main__':
     outfile = sys.stdout.buffer
     
     segment = bytearray(SEGMENT_SIZE)
+    ciphersegment = bytearray(lib.CIPHER_SEGMENT_SIZE)
     while True:
         segment_len = infile.readinto(segment)
 
         if segment_len == 0: # finito
             break
 
-        if segment_len < SEGMENT_SIZE: # not a full segment
-            data = bytes(segment[:segment_len]) # to discard the bytes from the previous segments
-            lib._encrypt_segment(data, outfile.write, session_key)
-            break
-
-        data = bytes(segment) # this is a full segment
-        lib._encrypt_segment(data, outfile.write, session_key)
+        clen = sodium.chacha20poly1305_encrypt(ciphersegment,
+                                               segment[:segment_len],
+                                               memoryview(session_key))
+        outfile.write(ciphersegment[:clen])
 
 


### PR DESCRIPTION
We bump the version to 1.8 (which would also include the change to docopt-ng).

In this PR, we remove the dependency to `pynacl`, which uses `cffi` and [forces the use of `bytes`](https://github.com/pyca/pynacl/blob/main/src/nacl/bindings/crypto_aead.py#L120-L275), rather than `bytearray`. That makes it difficult to use for big files, since every segment triggers lots of memory allocations instead of re-using the same buffer (see [pynacl issue#707](https://github.com/pyca/pynacl/issues/707)). Instead, we implemented a Python C extension that binds to libsodium (and tries to retain only the used functions in the final shared object).

We update the testsuite to run on macOS and ubuntu, for python versions 3.9 to 3.14. We adapt the compilation to a bundled libsodium, and to an already installed system-wide version.

We update the docs (showing on [readthedocs.org](https://crypt4gh.readthedocs.io/c-extension/)) to reflect the installation changes.

We did not push yet to PyPI (we will do so when the PR is merged, solving #52 at the same time).

**Efficiency**:
Here is a small benchmark: we encrypt a bigfile (10 GB) using version 1.7 and this new C-extension. We then decrypt the files using the version the other encrypted. We are using a Macbook Air 2025 (M4, 32 GB, with SSD).

We encrypt using version 1.7:
```
(v1.7) $ time crypt4gh encrypt --recipient_pk pubkey < bigfile > bigfile.old.c4gh                    
real  2m36.722s
user  2m34.142s
sys   0m2.200s
```

We encrypt using the C extension:
```
(v1.8) $ time crypt4gh encrypt --recipient_pk pubkey < bigfile > bigfile.c.c4gh                    
real  0m18.415s
user  0m14.699s
sys   0m1.968s
```


We decrypt using version 1.7:
```
(v1.7) $ time crypt4gh decrypt --sk seckey < bigfile.c.c4gh > bigfile.old.decrypted
real  2m36.260s
user  2m34.043s
sys   0m1.977s
```

We decrypt using the C extension:
```
(v1.8)$ time crypt4gh decrypt --sk seckey < bigfile.old.c4gh > bigfile.c.decrypted
real  0m28.526s
user  0m26.222s
sys   0m1.927s
```

Using `diff`, we get that `bigfile == bigfile.c.decrypted == bigfile.old.decrypted`

**Conclusion**: about 6 to 8 times faster ⇒ [Not too bad](https://www.youtube.com/watch?v=Kr0DIzqXkOQ)