### PR TITLE
Pushing to PyPI using Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: Publish wheels
 on: # only when we tag the master branch
   push:
     tags:
-      - v[0-9]+.*
+      - v[1-9]+.*
     branches:
-      - master
+      - releases/*
 
 jobs:
   build_wheels:
@@ -87,6 +87,7 @@ jobs:
 
 
   publish-to-testpypi:
+    if: github.ref_type == 'branch' && startsWith(github.ref_name, 'releases/')
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
 
@@ -105,12 +106,12 @@ jobs:
           path: dist
 
       - name: Publish distribution to Test PyPI
-        # if: github.ref_type == 'branch'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
 
   publish-to-pypi:
+    if: github.ref_type == 'tag'
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
 
@@ -129,5 +130,4 @@ jobs:
           path: dist
 
       - name: Publish distribution to PyPI
-        # if: github.ref_type == 'tag'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Publish wheels
 
-on: # only when we tag the master branch
+
+on:
   push:
     tags:
       - v[1-9]+.*
-    branches:
-      - releases/*
+    
 
 jobs:
   build_wheels:
@@ -87,7 +87,7 @@ jobs:
 
 
   publish-to-testpypi:
-    if: github.ref_type == 'branch' && startsWith(github.ref_name, 'releases/')
+    if: github.ref_type == 'tag' && github.event.base_ref != 'refs/heads/master'
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
 
@@ -111,7 +111,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-to-pypi:
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' && github.event.base_ref == 'refs/heads/master'
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -1,6 +1,13 @@
 name: Testsuite
 
-on: [push]
+on:
+  push:
+    branches:
+      # - master
+      # - releases/*
+      - '**' # cover everything
+    tags-ignore:
+      - '**'        # but never on tags
 
 jobs:
 

--- a/crypt4gh/__init__.py
+++ b/crypt4gh/__init__.py
@@ -37,7 +37,7 @@ cryptographic file format."""
 
 
 __title__ = 'GA4GH cryptographic utilities'
-__version__ = '1.8.1' # VERSION in header is 1 (as 4 bytes little endian)
+__version__ = '1.8.2' # VERSION in header is 1 (as 4 bytes little endian)
 __author__ = 'Frédéric Haziza'
 __author_email__ = 'silverdaz@gmail.com'
 __license__ = 'Apache License 2.0'

--- a/crypt4gh/__init__.py
+++ b/crypt4gh/__init__.py
@@ -37,7 +37,7 @@ cryptographic file format."""
 
 
 __title__ = 'GA4GH cryptographic utilities'
-__version__ = '1.8' # VERSION in header is 1 (as 4 bytes little endian)
+__version__ = '1.8.1' # VERSION in header is 1 (as 4 bytes little endian)
 __author__ = 'Frédéric Haziza'
 __author_email__ = 'silverdaz@gmail.com'
 __license__ = 'Apache License 2.0'

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ class BashCompletion(install):
             print('Could not install bash completion:', repr(e), file=sys.stderr)
 
 setup(name='crypt4gh',
-      version='1.8.1',
+      version='1.8.2',
       url='https://www.github.com/EGA-archive/crypt4gh',
       license='Apache License 2.0',
       author='Frédéric Haziza',

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ class BashCompletion(install):
             print('Could not install bash completion:', repr(e), file=sys.stderr)
 
 setup(name='crypt4gh',
-      version='1.8',
+      version='1.8.1',
       url='https://www.github.com/EGA-archive/crypt4gh',
       license='Apache License 2.0',
       author='Frédéric Haziza',


### PR DESCRIPTION
We add a release.yml separate workflow to push packages to PyPI.

For every branch, we run the testsuite.

When we tag, we run the release workflow. If the tag is on master, it goes to PyPI, if not, it goes to Test PyPI.

I configured PyPI to use [Trusted Publishers](https://docs.pypi.org/trusted-publishers/)

This PR was made from a separate branch that we tagged, to test pushing to Test PyPI.
That worked: we have [crypt4gh 1.8.2](https://test.pypi.org/manage/project/crypt4gh/release/1.8.2/) python package.

That PR solves #52 